### PR TITLE
Fix template params to match final C++17 iterator categories

### DIFF
--- a/include/pstl/algorithm
+++ b/include/pstl/algorithm
@@ -1,3 +1,5 @@
+// <algorithm> -*- C++ -*-
+
 /*
     Copyright (c) 2017-2018 Intel Corporation
 
@@ -32,50 +34,50 @@ namespace std {
 
 // [alg.any_of]
 
-template<class ExecutionPolicy, class InputIterator, class Predicate>
+template<class ExecutionPolicy, class ForwardIterator, class Predicate>
 pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-any_of(ExecutionPolicy&& exec, InputIterator first, InputIterator last, Predicate pred) {
+any_of(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, Predicate pred) {
     using namespace pstl::internal;
     return pattern_any_of( first, last, pred,
-        is_vectorization_preferred<ExecutionPolicy,InputIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy,InputIterator>(exec));
+        is_vectorization_preferred<ExecutionPolicy,ForwardIterator>(exec),
+        is_parallelization_preferred<ExecutionPolicy,ForwardIterator>(exec));
 }
 
 // [alg.all_of]
 
-template<class ExecutionPolicy, class InputIterator, class Pred>
+template<class ExecutionPolicy, class ForwardIterator, class Pred>
 pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-all_of(ExecutionPolicy&& exec, InputIterator first, InputIterator last, Pred pred) {
+all_of(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, Pred pred) {
     return !any_of(std::forward<ExecutionPolicy>(exec), first, last, pstl::internal::not_pred<Pred>(pred));
 }
 
 // [alg.none_of]
 
-template<class ExecutionPolicy, class InputIterator, class Predicate>
+template<class ExecutionPolicy, class ForwardIterator, class Predicate>
 pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-none_of(ExecutionPolicy&& exec, InputIterator first, InputIterator last, Predicate pred) {
+none_of(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, Predicate pred) {
     return !any_of( std::forward<ExecutionPolicy>(exec), first, last, pred );
 }
 
 // [alg.foreach]
 
-template<class ExecutionPolicy, class InputIterator, class Function>
+template<class ExecutionPolicy, class ForwardIterator, class Function>
 pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-for_each(ExecutionPolicy&& exec, InputIterator first, InputIterator last, Function f) {
+for_each(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, Function f) {
     using namespace pstl::internal;
     pattern_walk1(
         first, last, f,
-        is_vectorization_preferred<ExecutionPolicy,InputIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy,InputIterator>(exec));
+        is_vectorization_preferred<ExecutionPolicy,ForwardIterator>(exec),
+        is_parallelization_preferred<ExecutionPolicy,ForwardIterator>(exec));
 }
 
-template<class ExecutionPolicy, class InputIterator, class Size, class Function>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, InputIterator>
-for_each_n(ExecutionPolicy&& exec, InputIterator first, Size n, Function f) {
+template<class ExecutionPolicy, class ForwardIterator, class Size, class Function>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
+for_each_n(ExecutionPolicy&& exec, ForwardIterator first, Size n, Function f) {
     using namespace pstl::internal;
     return pattern_walk1_n(first, n, f,
-        is_vectorization_preferred<ExecutionPolicy,InputIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy,InputIterator>(exec));
+        is_vectorization_preferred<ExecutionPolicy,ForwardIterator>(exec),
+        is_parallelization_preferred<ExecutionPolicy,ForwardIterator>(exec));
 }
 
 // [alg.find]
@@ -145,13 +147,13 @@ adjacent_find(ExecutionPolicy&& exec, ForwardIt first, ForwardIt last) {
        is_vectorization_preferred<ExecutionPolicy, ForwardIt>(exec), /*first_semantic*/ false);
 }
 
-template< class ExecutionPolicy, class ForwardIt, class BinaryPredicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIt>
-adjacent_find(ExecutionPolicy&& exec, ForwardIt first, ForwardIt last, BinaryPredicate pred) {
+template< class ExecutionPolicy, class ForwardIterator, class BinaryPredicate>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
+adjacent_find(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, BinaryPredicate pred) {
     using namespace pstl::internal;
     return pattern_adjacent_find(first, last, pred,
-       is_parallelization_preferred<ExecutionPolicy, ForwardIt>(exec),
-       is_vectorization_preferred<ExecutionPolicy, ForwardIt>(exec), /*first_semantic*/ false);
+       is_parallelization_preferred<ExecutionPolicy, ForwardIterator>(exec),
+       is_vectorization_preferred<ExecutionPolicy, ForwardIterator>(exec), /*first_semantic*/ false);
 }
 
 // [alg.count]
@@ -212,38 +214,38 @@ search_n(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, Si
 
 // [alg.copy]
 
-template<class ExecutionPolicy, class InputIterator, class OutputIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,OutputIterator>
-copy(ExecutionPolicy&& exec, InputIterator first, InputIterator last, OutputIterator result) {
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
+copy(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result) {
     using namespace pstl::internal;
-    const auto is_vector = is_vectorization_preferred<ExecutionPolicy, InputIterator, OutputIterator>(exec);
+    const auto is_vector = is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec);
 
-    return pattern_walk2_brick(first, last, result, [is_vector](InputIterator begin, InputIterator end, OutputIterator res){
+    return pattern_walk2_brick(first, last, result, [is_vector](ForwardIterator1 begin, ForwardIterator1 end, ForwardIterator2 res){
         return brick_copy(begin, end, res, is_vector);
-    }, is_parallelization_preferred<ExecutionPolicy, InputIterator, OutputIterator>(exec));
+    }, is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec));
 }
 
-template<class ExecutionPolicy, class InputIterator, class Size, class OutputIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,OutputIterator>
-copy_n(ExecutionPolicy&& exec, InputIterator first, Size n, OutputIterator result) {
+template<class ExecutionPolicy, class ForwardIterator1, class Size, class ForwardIterator2>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
+copy_n(ExecutionPolicy&& exec, ForwardIterator1 first, Size n, ForwardIterator2 result) {
     using namespace pstl::internal;
-    const auto is_vector = is_vectorization_preferred<ExecutionPolicy, InputIterator, OutputIterator>(exec);
+    const auto is_vector = is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec);
 
-    return pattern_walk2_brick_n(first, n, result, [is_vector](InputIterator begin, Size sz, OutputIterator res){
+    return pattern_walk2_brick_n(first, n, result, [is_vector](ForwardIterator1 begin, Size sz, ForwardIterator2 res){
         return brick_copy_n(begin, sz, res, is_vector);
-    }, is_parallelization_preferred<ExecutionPolicy, InputIterator, OutputIterator>(exec));
+    }, is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec));
 }
 
-template<class ExecutionPolicy, class InputIterator, class OutputIterator, class Predicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,OutputIterator>
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class Predicate>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
 copy_if(ExecutionPolicy&& exec,
-        InputIterator first, InputIterator last,
-        OutputIterator result, Predicate pred) {
+        ForwardIterator1 first, ForwardIterator1 last,
+        ForwardIterator2 result, Predicate pred) {
     using namespace pstl::internal;
     return pattern_copy_if(
         first, last, result, pred,
-        is_vectorization_preferred<ExecutionPolicy,InputIterator,OutputIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy,InputIterator,OutputIterator>(exec));
+        is_vectorization_preferred<ExecutionPolicy,ForwardIterator1,ForwardIterator2>(exec),
+        is_parallelization_preferred<ExecutionPolicy,ForwardIterator1,ForwardIterator2>(exec));
 }
 
 // [alg.swap]
@@ -259,28 +261,28 @@ swap_ranges(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 la
 
 // [alg.transform]
 
-template<class ExecutionPolicy, class InputIterator, class OutputIterator, class UnaryOperation>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,OutputIterator>
-transform( ExecutionPolicy&& exec, InputIterator first, InputIterator last, OutputIterator result, UnaryOperation op ) {
-    typedef typename iterator_traits<InputIterator>::reference input_type;
-    typedef typename iterator_traits<OutputIterator>::reference output_type;
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class UnaryOperation>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
+transform( ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, UnaryOperation op ) {
+    typedef typename iterator_traits<ForwardIterator1>::reference input_type;
+    typedef typename iterator_traits<ForwardIterator2>::reference output_type;
     using namespace pstl::internal;
     return pattern_walk2(first, last, result,
         [op](input_type x, output_type y ) mutable { y = op(x);},
-        is_vectorization_preferred<ExecutionPolicy,InputIterator,OutputIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy,InputIterator,OutputIterator>(exec));
+        is_vectorization_preferred<ExecutionPolicy,ForwardIterator1,ForwardIterator2>(exec),
+        is_parallelization_preferred<ExecutionPolicy,ForwardIterator1,ForwardIterator2>(exec));
 }
 
-template<class ExecutionPolicy, class InputIterator1, class InputIterator2, class OutputIterator, class BinaryOperation>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,OutputIterator>
-transform( ExecutionPolicy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, OutputIterator result, BinaryOperation op ) {
-    typedef typename iterator_traits<InputIterator1>::reference input1_type;
-    typedef typename iterator_traits<InputIterator2>::reference input2_type;
-    typedef typename iterator_traits<OutputIterator>::reference output_type;
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class ForwardIterator, class BinaryOperation>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator>
+transform( ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator result, BinaryOperation op ) {
+    typedef typename iterator_traits<ForwardIterator1>::reference input1_type;
+    typedef typename iterator_traits<ForwardIterator2>::reference input2_type;
+    typedef typename iterator_traits<ForwardIterator>::reference output_type;
     using namespace pstl::internal;
-    return pattern_walk3(first1, last1, first2, result, [op](input1_type x, input2_type y, output_type z ) mutable {z = op(x,y);},
-        is_vectorization_preferred<ExecutionPolicy,InputIterator1,InputIterator2,OutputIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy,InputIterator1,InputIterator2,OutputIterator>(exec));
+    return pattern_walk3(first1, last1, first2, result, [op]( input1_type x, input2_type y, output_type z ) mutable {z = op(x,y);},
+        is_vectorization_preferred<ExecutionPolicy,ForwardIterator1,ForwardIterator2,ForwardIterator>(exec),
+        is_parallelization_preferred<ExecutionPolicy,ForwardIterator1,ForwardIterator2,ForwardIterator>(exec));
 }
 
 // [alg.replace]
@@ -305,23 +307,23 @@ replace(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, con
     replace_if(std::forward<ExecutionPolicy>(exec), first, last, pstl::internal::equal_value<T>(old_value), new_value);
 }
 
-template<class ExecutionPolicy, class InputIterator, class OutputIterator, class UnaryPredicate, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, OutputIterator>
-replace_copy_if(ExecutionPolicy&& exec, InputIterator first, InputIterator last, OutputIterator result, UnaryPredicate pred, const T& new_value) {
-    typedef typename iterator_traits<InputIterator>::reference input_type;
-    typedef typename iterator_traits<OutputIterator>::reference output_type;
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class UnaryPredicate, class T>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator2>
+replace_copy_if(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, UnaryPredicate pred, const T& new_value) {
+    typedef typename iterator_traits<ForwardIterator1>::reference input_type;
+    typedef typename iterator_traits<ForwardIterator2>::reference output_type;
     using namespace pstl::internal;
     return pattern_walk2(
         first, last, result,
         [pred, &new_value](input_type x, output_type y) mutable { y = pred(x) ? new_value : x; },
-        is_vectorization_preferred<ExecutionPolicy, InputIterator, OutputIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy, InputIterator, OutputIterator>(exec));
+        is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec),
+        is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec));
 }
 
-template<class ExecutionPolicy, class InputIterator, class OutputIterator, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, OutputIterator>
-replace_copy(ExecutionPolicy&& exec, InputIterator first, InputIterator last, OutputIterator result, const T& old_value, const T& new_value) {
-    return replace_copy_if(std::forward<ExecutionPolicy>(exec), first, last, result, pstl::internal::equal_value<T>(old_value), new_value);
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class T>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator2>
+replace_copy(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, const T& old_value, const T& new_value) {
+    return replace_copy_if(exec, first, last, result, pstl::internal::equal_value<T>(old_value), new_value);
 }
 
 // [alg.fill]
@@ -335,16 +337,16 @@ fill( ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, const
         is_vectorization_preferred<ExecutionPolicy, ForwardIterator>(exec));
 }
 
-template< class ExecutionPolicy, class OutputIterator, class Size, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, OutputIterator>
-fill_n( ExecutionPolicy&& exec, OutputIterator first, Size count, const T& value ) {
+template< class ExecutionPolicy, class ForwardIterator, class Size, class T>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
+fill_n( ExecutionPolicy&& exec, ForwardIterator first, Size count, const T& value ) {
     if(count <= 0)
         return first;
 
     using namespace pstl::internal;
     return pattern_fill_n(first, count, value,
-        is_parallelization_preferred<ExecutionPolicy, OutputIterator>(exec),
-        is_vectorization_preferred<ExecutionPolicy, OutputIterator>(exec));
+        is_parallelization_preferred<ExecutionPolicy, ForwardIterator>(exec),
+        is_vectorization_preferred<ExecutionPolicy, ForwardIterator>(exec));
 }
 
 // [alg.generate]
@@ -357,29 +359,29 @@ generate( ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, G
         is_vectorization_preferred<ExecutionPolicy, ForwardIterator>(exec));
 }
 
-template< class ExecutionPolicy, class OutputIterator, class Size, class Generator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, OutputIterator>
-generate_n( ExecutionPolicy&& exec, OutputIterator first, Size count, Generator g ) {
+template< class ExecutionPolicy, class ForwardIterator, class Size, class Generator>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
+generate_n( ExecutionPolicy&& exec, ForwardIterator first, Size count, Generator g ) {
     if(count <= 0)
         return first;
 
     using namespace pstl::internal;
     return pattern_generate_n(first, count, g,
-        is_parallelization_preferred<ExecutionPolicy, OutputIterator>(exec),
-        is_vectorization_preferred<ExecutionPolicy, OutputIterator>(exec));
+        is_parallelization_preferred<ExecutionPolicy, ForwardIterator>(exec),
+        is_vectorization_preferred<ExecutionPolicy, ForwardIterator>(exec));
 }
 
 // [alg.remove]
 
-template<class ExecutionPolicy, class InputIterator, class OutputIterator, class Predicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,OutputIterator>
-remove_copy_if(ExecutionPolicy&& exec, InputIterator first, InputIterator last, OutputIterator result, Predicate pred) {
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class Predicate>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
+remove_copy_if(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, Predicate pred) {
     return copy_if(std::forward<ExecutionPolicy>(exec), first, last, result, pstl::internal::not_pred<Predicate>(pred));
 }
 
-template<class ExecutionPolicy, class InputIterator, class OutputIterator, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,OutputIterator>
-remove_copy(ExecutionPolicy&& exec, InputIterator first, InputIterator last, OutputIterator result, const T& value) {
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class T>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
+remove_copy(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, const T& value) {
     return copy_if(std::forward<ExecutionPolicy>(exec), first, last, result, pstl::internal::not_equal_value<T>(value));
 }
 
@@ -415,18 +417,18 @@ unique(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last) {
     return unique(std::forward<ExecutionPolicy>(exec), first, last, pstl::internal::pstl_equal());
 }
 
-template<class ExecutionPolicy, class InputIterator, class OutputIterator, class BinaryPredicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,OutputIterator>
-unique_copy(ExecutionPolicy&& exec, InputIterator first, InputIterator last, OutputIterator result, BinaryPredicate pred) {
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class BinaryPredicate>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
+unique_copy(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, BinaryPredicate pred) {
     using namespace pstl::internal;
     return pattern_unique_copy(first, last, result, pred,
-        is_vectorization_preferred<ExecutionPolicy,InputIterator,OutputIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy,InputIterator,OutputIterator>(exec));
+        is_vectorization_preferred<ExecutionPolicy,ForwardIterator1,ForwardIterator2>(exec),
+        is_parallelization_preferred<ExecutionPolicy,ForwardIterator1,ForwardIterator2>(exec));
 }
 
-template<class ExecutionPolicy, class InputIterator, class OutputIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,OutputIterator>
-unique_copy(ExecutionPolicy&& exec, InputIterator first, InputIterator last, OutputIterator result) {
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
+unique_copy(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result) {
     return unique_copy(std::forward<ExecutionPolicy>(exec), first, last, result, pstl::internal::pstl_equal() );
 }
 
@@ -441,13 +443,13 @@ reverse(ExecutionPolicy&& exec, BidirectionalIterator first, BidirectionalIterat
         is_parallelization_preferred<ExecutionPolicy, BidirectionalIterator>(exec));
 }
 
-template<class ExecutionPolicy, class BidirectionalIterator, class OutputIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, OutputIterator>
-reverse_copy(ExecutionPolicy&& exec, BidirectionalIterator first, BidirectionalIterator last, OutputIterator d_first) {
+template<class ExecutionPolicy, class BidirectionalIterator, class ForwardIterator>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
+reverse_copy(ExecutionPolicy&& exec, BidirectionalIterator first, BidirectionalIterator last, ForwardIterator d_first) {
     using namespace pstl::internal;
     return pattern_reverse_copy(first, last, d_first,
-        is_vectorization_preferred<ExecutionPolicy, BidirectionalIterator, OutputIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy, BidirectionalIterator, OutputIterator>(exec));
+        is_vectorization_preferred<ExecutionPolicy, BidirectionalIterator, ForwardIterator>(exec),
+        is_parallelization_preferred<ExecutionPolicy, BidirectionalIterator, ForwardIterator>(exec));
 }
 
 // [alg.rotate]
@@ -461,24 +463,24 @@ rotate(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator middle, Fo
         is_parallelization_preferred<ExecutionPolicy, ForwardIterator>(exec));
 }
 
-template<class ExecutionPolicy, class ForwardIterator, class OutputIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, OutputIterator>
-rotate_copy(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator middle, ForwardIterator last, OutputIterator result) {
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator2>
+rotate_copy(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 middle, ForwardIterator1 last, ForwardIterator2 result) {
     using namespace pstl::internal;
     return pattern_rotate_copy(first, middle, last, result,
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator, OutputIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy, ForwardIterator, OutputIterator>(exec));
+        is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec),
+        is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec));
 }
 
 // [alg.partitions]
 
-template<class ExecutionPolicy, class InputIterator, class UnaryPredicate>
+template<class ExecutionPolicy, class ForwardIterator, class UnaryPredicate>
 pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-is_partitioned(ExecutionPolicy&& exec, InputIterator first, InputIterator last, UnaryPredicate pred) {
+is_partitioned(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, UnaryPredicate pred) {
     using namespace pstl::internal;
     return pattern_is_partitioned(first, last, pred,
-        is_vectorization_preferred<ExecutionPolicy, InputIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy, InputIterator>(exec));
+        is_vectorization_preferred<ExecutionPolicy, ForwardIterator>(exec),
+        is_parallelization_preferred<ExecutionPolicy, ForwardIterator>(exec));
 }
 
 template<class ExecutionPolicy, class ForwardIterator, class UnaryPredicate>
@@ -499,13 +501,13 @@ stable_partition(ExecutionPolicy&& exec, BidirectionalIterator first, Bidirectio
         is_parallelization_preferred<ExecutionPolicy, BidirectionalIterator>(exec));
 }
 
-template<class ExecutionPolicy, class InputIterator, class OutputIterator1, class OutputIterator2, class UnaryPredicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, std::pair<OutputIterator1, OutputIterator2>>
-partition_copy(ExecutionPolicy&& exec, InputIterator first, InputIterator last, OutputIterator1 out_true, OutputIterator2 out_false, UnaryPredicate pred) {
+template<class ExecutionPolicy, class ForwardIterator, class ForwardIterator1, class ForwardIterator2, class UnaryPredicate>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy, std::pair<ForwardIterator1, ForwardIterator2>>
+partition_copy(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, ForwardIterator1 out_true, ForwardIterator2 out_false, UnaryPredicate pred) {
     using namespace pstl::internal;
     return pattern_partition_copy(first, last, out_true, out_false, pred,
-        is_vectorization_preferred<ExecutionPolicy, InputIterator, OutputIterator1, OutputIterator2>(exec),
-        is_parallelization_preferred<ExecutionPolicy, InputIterator, OutputIterator1, OutputIterator2>(exec));
+        is_vectorization_preferred<ExecutionPolicy, ForwardIterator, ForwardIterator1, ForwardIterator2>(exec),
+        is_parallelization_preferred<ExecutionPolicy, ForwardIterator, ForwardIterator1, ForwardIterator2>(exec));
 }
 
 // [alg.sort]
@@ -546,76 +548,77 @@ stable_sort(ExecutionPolicy&& exec, RandomAccessIterator first, RandomAccessIter
 
 // [mismatch]
 
-template< class ExecutionPolicy, class InputIterator1, class InputIterator2, class BinaryPredicate >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, std::pair<InputIterator1, InputIterator2>>
-mismatch(ExecutionPolicy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, BinaryPredicate pred) {
+template< class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class BinaryPredicate >
+pstl::internal::enable_if_execution_policy<ExecutionPolicy, std::pair<ForwardIterator1, ForwardIterator2>>
+mismatch(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2, BinaryPredicate pred) {
     using namespace pstl::internal;
     return pattern_mismatch(first1, last1, first2, last2, pred,
-        is_vectorization_preferred<ExecutionPolicy, InputIterator1, InputIterator2>(exec),
-        is_parallelization_preferred<ExecutionPolicy, InputIterator1, InputIterator2>(exec));
+        is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec),
+        is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec));
 }
 
-template< class ExecutionPolicy, class InputIterator1, class InputIterator2, class BinaryPredicate >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, std::pair<InputIterator1, InputIterator2>>
-mismatch(ExecutionPolicy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, BinaryPredicate pred) {
+template< class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class BinaryPredicate >
+pstl::internal::enable_if_execution_policy<ExecutionPolicy, std::pair<ForwardIterator1, ForwardIterator2>>
+mismatch(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, BinaryPredicate pred) {
     return mismatch(std::forward<ExecutionPolicy>(exec), first1, last1, first2, std::next(first2, std::distance(first1, last1)), pred);
 }
 
-template< class ExecutionPolicy, class InputIterator1, class InputIterator2 >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, std::pair<InputIterator1, InputIterator2>>
-mismatch(ExecutionPolicy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2) {
-    return mismatch(std::forward<ExecutionPolicy>(exec), first1, last1, first2, last2, pstl::internal::pstl_equal());
+template< class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2 >
+pstl::internal::enable_if_execution_policy<ExecutionPolicy, std::pair<ForwardIterator1, ForwardIterator2>>
+mismatch(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2) {
+    typedef typename iterator_traits<ForwardIterator1>::value_type value_type;
+    return mismatch(std::forward<ExecutionPolicy>(exec), first1, last1, first2, last2, std::equal_to<value_type>());
 }
 
-template< class ExecutionPolicy, class InputIterator1, class InputIterator2 >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, std::pair<InputIterator1, InputIterator2>>
-mismatch(ExecutionPolicy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2) {
+template< class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2 >
+pstl::internal::enable_if_execution_policy<ExecutionPolicy, std::pair<ForwardIterator1, ForwardIterator2>>
+mismatch(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2) {
     return mismatch(std::forward<ExecutionPolicy>(exec), first1, last1, first2, std::next(first2, std::distance(first1, last1)));
 }
 
 // [alg.equal]
 
-template<class ExecutionPolicy, class InputIterator1, class InputIterator2, class BinaryPredicate>
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class BinaryPredicate>
 pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-equal(ExecutionPolicy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, BinaryPredicate p) {
+equal(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, BinaryPredicate p) {
     using namespace pstl::internal;
     return pattern_equal(first1, last1, first2, p,
-        is_vectorization_preferred<ExecutionPolicy, InputIterator1>(exec),
-        is_parallelization_preferred<ExecutionPolicy, InputIterator1>(exec)
+        is_vectorization_preferred<ExecutionPolicy, ForwardIterator1>(exec),
+        is_parallelization_preferred<ExecutionPolicy, ForwardIterator1>(exec)
         );
 }
 
-template<class ExecutionPolicy, class InputIterator1, class InputIterator2>
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
 pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-equal(ExecutionPolicy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2) {
-    return equal(std::forward<ExecutionPolicy>(exec), first1, last1, first2, pstl::internal::pstl_equal());
+equal(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2) {
+  return equal(std::forward<ExecutionPolicy>(exec), first1, last1, first2, pstl::internal::pstl_equal());
 }
 
-template<class ExecutionPolicy, class InputIterator1, class InputIterator2, class BinaryPredicate>
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class BinaryPredicate>
 pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-equal(ExecutionPolicy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, BinaryPredicate p) {
+equal(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2, BinaryPredicate p) {
     if ( std::distance(first1, last1) == std::distance(first2, last2) )
         return std::equal(first1, last1, first2, p);
     else
         return false;
 }
 
-template<class ExecutionPolicy, class InputIterator1, class InputIterator2>
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
 pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-equal(ExecutionPolicy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2) {
+equal(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2) {
     return equal(first1, last1, first2, pstl::internal::pstl_equal());
 }
 
 // [alg.move]
-template< class ExecutionPolicy, class InputIterator, class OutputIterator >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, OutputIterator>
-move(ExecutionPolicy&& exec, InputIterator first, InputIterator last, OutputIterator d_first) {
+template< class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2 >
+pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator2>
+move(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 d_first) {
     using namespace pstl::internal;
-    const auto is_vector = is_vectorization_preferred<ExecutionPolicy, InputIterator, OutputIterator>(exec);
+    const auto is_vector = is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec);
 
-    return pattern_walk2_brick(first, last, d_first, [is_vector](InputIterator begin, InputIterator end, OutputIterator res) {
+    return pattern_walk2_brick(first, last, d_first, [is_vector](ForwardIterator1 begin, ForwardIterator1 end, ForwardIterator2 res) {
         return brick_move(begin, end, res, is_vector);
-    }, is_parallelization_preferred<ExecutionPolicy, InputIterator, OutputIterator>(exec));
+    }, is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec));
 }
 
 // [partial.sort]
@@ -637,19 +640,20 @@ partial_sort(ExecutionPolicy&& exec, RandomAccessIterator first, RandomAccessIte
 
 // [partial.sort.copy]
 
-template<class ExecutionPolicy, class InputIterator, class RandomAccessIterator, class Compare>
+template<class ExecutionPolicy, class _InputIterator, class RandomAccessIterator, class Compare>
 pstl::internal::enable_if_execution_policy<ExecutionPolicy, RandomAccessIterator>
-partial_sort_copy(ExecutionPolicy&& exec, InputIterator first, InputIterator last, RandomAccessIterator d_first, RandomAccessIterator d_last, Compare comp) {
+partial_sort_copy(ExecutionPolicy&& exec, _InputIterator first, _InputIterator last, RandomAccessIterator d_first, RandomAccessIterator d_last, Compare comp) {
     using namespace pstl::internal;
     return pattern_partial_sort_copy(first, last, d_first, d_last, comp,
-        is_vectorization_preferred<ExecutionPolicy, InputIterator, RandomAccessIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy, InputIterator, RandomAccessIterator>(exec));
+        is_vectorization_preferred<ExecutionPolicy, _InputIterator, RandomAccessIterator>(exec),
+        is_parallelization_preferred<ExecutionPolicy, _InputIterator, RandomAccessIterator>(exec));
 }
 
-template<class ExecutionPolicy, class InputIterator, class RandomAccessIterator>
+template<class ExecutionPolicy, class ForwardIterator, class RandomAccessIterator>
 pstl::internal::enable_if_execution_policy<ExecutionPolicy, RandomAccessIterator>
-partial_sort_copy(ExecutionPolicy&& exec, InputIterator first, InputIterator last, RandomAccessIterator d_first, RandomAccessIterator d_last) {
-    return partial_sort_copy(std::forward<ExecutionPolicy>(exec), first, last, d_first, d_last, pstl::internal::pstl_less());
+partial_sort_copy(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, RandomAccessIterator d_first, RandomAccessIterator d_last) {
+    typedef typename iterator_traits<ForwardIterator>::value_type input_type;
+    return partial_sort_copy(std::forward<ExecutionPolicy>(exec), first, last, d_first, d_last, std::less<input_type>());
 }
 
 // [is.sorted]
@@ -702,19 +706,20 @@ nth_element(ExecutionPolicy&& exec, RandomAccessIterator first, RandomAccessIter
 }
 
 // [alg.merge]
-template< class ExecutionPolicy, class InputIterator1, class InputIterator2, class OutputIterator, class Compare>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, OutputIterator>
-merge(ExecutionPolicy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, OutputIterator d_first, Compare comp) {
+template< class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class ForwardIterator, class Compare>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
+merge(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2, ForwardIterator d_first, Compare comp) {
     using namespace pstl::internal;
     return pattern_merge(first1, last1, first2, last2, d_first, comp,
-        is_vectorization_preferred<ExecutionPolicy, InputIterator1, InputIterator2, OutputIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy, InputIterator1, InputIterator2, OutputIterator>(exec));
+        is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2, ForwardIterator>(exec),
+        is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2, ForwardIterator>(exec));
 }
 
-template< class ExecutionPolicy, class InputIterator1, class InputIterator2, class OutputIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, OutputIterator>
-merge(ExecutionPolicy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, OutputIterator d_first) {
-    return merge(std::forward<ExecutionPolicy>(exec), first1, last1, first2, last2, d_first, pstl::internal::pstl_less());
+template< class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class ForwardIterator>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
+merge(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2, ForwardIterator d_first) {
+    typedef typename iterator_traits<ForwardIterator1>::value_type value_type;
+    return merge(std::forward<ExecutionPolicy>(exec), first1, last1, first2, last2, d_first, std::less<value_type>());
 }
 
 template< class ExecutionPolicy, class BidirectionalIterator, class Compare>
@@ -734,87 +739,88 @@ inplace_merge(ExecutionPolicy&& exec, BidirectionalIterator first, Bidirectional
 
 // [includes]
 
-template< class ExecutionPolicy, class InputIterator1, class InputIterator2, class Compare>
+template< class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class Compare>
 pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-includes(ExecutionPolicy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, Compare comp) {
+includes(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2, Compare comp) {
     using namespace pstl::internal;
     return pattern_includes(first1, last1, first2, last2, comp,
-        is_vectorization_preferred<ExecutionPolicy, InputIterator1, InputIterator2>(exec),
-        is_parallelization_preferred<ExecutionPolicy, InputIterator1, InputIterator2>(exec));
+        is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec),
+        is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec));
 }
 
-template< class ExecutionPolicy, class InputIterator1, class InputIterator2>
+template< class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
 pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-includes(ExecutionPolicy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2) {
-    return includes(std::forward<ExecutionPolicy>(exec), first1, last1, first2, last2, pstl::internal::pstl_less());
+includes(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2) {
+    typedef typename iterator_traits<ForwardIterator1>::value_type value_type;
+    return includes(std::forward<ExecutionPolicy>(exec), first1, last1, first2, last2, std::less<value_type>());
 }
 
 // [set.union]
 
-template<class ExecutionPolicy, class InputIterator1, class InputIterator2, class OutputIterator, class Compare>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, OutputIterator>
-set_union(ExecutionPolicy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, OutputIterator result, Compare comp) {
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class ForwardIterator, class Compare>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
+set_union(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2, ForwardIterator result, Compare comp) {
     using namespace pstl::internal;
     return pattern_set_union(first1, last1, first2, last2, result, comp,
-        is_vectorization_preferred<ExecutionPolicy, InputIterator1, InputIterator2, OutputIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy, InputIterator1, InputIterator2, OutputIterator>(exec));
+        is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2, ForwardIterator>(exec),
+        is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2, ForwardIterator>(exec));
 }
 
-template<class ExecutionPolicy, class InputIterator1, class InputIterator2, class OutputIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, OutputIterator>
-set_union(ExecutionPolicy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
-    InputIterator2 last2, OutputIterator result) {
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class ForwardIterator>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
+set_union(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2,
+              ForwardIterator2 last2, ForwardIterator result) {
     return set_union(std::forward<ExecutionPolicy>(exec), first1, last1, first2, last2, result, pstl::internal::pstl_less());
 }
 
 // [set.intersection]
 
-template<class ExecutionPolicy, class InputIterator1, class InputIterator2, class OutputIterator, class Compare>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, OutputIterator>
-set_intersection(ExecutionPolicy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, OutputIterator result, Compare comp) {
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class ForwardIterator, class Compare>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
+set_intersection(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2, ForwardIterator result, Compare comp) {
     using namespace pstl::internal;
     return pattern_set_intersection(first1, last1, first2, last2, result, comp,
-        is_vectorization_preferred<ExecutionPolicy, InputIterator1, InputIterator2, OutputIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy, InputIterator1, InputIterator2, OutputIterator>(exec));
+        is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2, ForwardIterator>(exec),
+        is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2, ForwardIterator>(exec));
 }
 
-template<class ExecutionPolicy, class InputIterator1, class InputIterator2, class OutputIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, OutputIterator>
-set_intersection(ExecutionPolicy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, OutputIterator result) {
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class ForwardIterator>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
+set_intersection(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2, ForwardIterator result) {
     return set_intersection(std::forward<ExecutionPolicy>(exec), first1, last1, first2, last2, result, pstl::internal::pstl_less());
 }
 
 // [set.difference]
 
-template<class ExecutionPolicy, class InputIterator1, class InputIterator2, class OutputIterator, class Compare>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, OutputIterator>
-set_difference(ExecutionPolicy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, OutputIterator result, Compare comp) {
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class ForwardIterator, class Compare>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
+set_difference(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2, ForwardIterator result, Compare comp) {
     using namespace pstl::internal;
     return pattern_set_difference(first1, last1, first2, last2, result, comp,
-        is_vectorization_preferred<ExecutionPolicy, InputIterator1, InputIterator2, OutputIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy, InputIterator1, InputIterator2, OutputIterator>(exec));
+        is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2, ForwardIterator>(exec),
+        is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2, ForwardIterator>(exec));
 }
 
-template<class ExecutionPolicy, class InputIterator1, class InputIterator2, class OutputIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, OutputIterator>
-set_difference(ExecutionPolicy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, OutputIterator result) {
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class ForwardIterator>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
+set_difference(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2, ForwardIterator result) {
     return set_difference(std::forward<ExecutionPolicy>(exec), first1, last1, first2, last2, result, pstl::internal::pstl_less());
 }
 
 // [set.symmetric.difference]
 
-template<class ExecutionPolicy, class InputIterator1, class InputIterator2, class OutputIterator, class Compare>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, OutputIterator>
-set_symmetric_difference(ExecutionPolicy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, OutputIterator result, Compare comp) {
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class ForwardIterator, class Compare>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
+set_symmetric_difference(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2, ForwardIterator result, Compare comp) {
     using namespace pstl::internal;
     return pattern_set_symmetric_difference(first1, last1, first2, last2, result, comp,
-        is_vectorization_preferred<ExecutionPolicy, InputIterator1, InputIterator2, OutputIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy, InputIterator1, InputIterator2, OutputIterator>(exec));
+        is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2, ForwardIterator>(exec),
+        is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2, ForwardIterator>(exec));
 }
 
-template<class ExecutionPolicy, class InputIterator1, class InputIterator2, class OutputIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, OutputIterator>
-set_symmetric_difference(ExecutionPolicy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, OutputIterator result) {
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class ForwardIterator>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
+set_symmetric_difference(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2, ForwardIterator result) {
     return set_symmetric_difference(std::forward<ExecutionPolicy>(exec), first1, last1, first2, last2, result, pstl::internal::pstl_less());
 }
 
@@ -902,18 +908,18 @@ minmax_element(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator la
 
 // [alg.lex.comparison]
 
-template< class ExecutionPolicy, class InputIterator1, class InputIterator2, class Compare >
+template< class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class Compare >
 pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-lexicographical_compare(ExecutionPolicy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, Compare comp) {
+lexicographical_compare(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2, Compare comp) {
     using namespace pstl::internal;
     return pattern_lexicographical_compare(first1, last1, first2, last2, comp,
-        is_vectorization_preferred<ExecutionPolicy, InputIterator1, InputIterator2>(exec),
-        is_parallelization_preferred<ExecutionPolicy, InputIterator1, InputIterator2>(exec));
+        is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec),
+        is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec));
 }
 
-template< class ExecutionPolicy, class InputIterator1, class InputIterator2 >
+template< class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2 >
 pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-lexicographical_compare(ExecutionPolicy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2) {
+lexicographical_compare(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2) {
     return lexicographical_compare(std::forward<ExecutionPolicy>(exec), first1, last1, first2, last2, pstl::internal::pstl_less());
 }
 

--- a/include/pstl/memory
+++ b/include/pstl/memory
@@ -1,3 +1,5 @@
+// <numeric> -*- C++ -*-
+
 /*
     Copyright (c) 2017-2018 Intel Corporation
 

--- a/include/pstl/numeric
+++ b/include/pstl/numeric
@@ -1,3 +1,5 @@
+// <numeric> -*- C++ -*-
+
 /*
     Copyright (c) 2017-2018 Intel Corporation
 
@@ -31,118 +33,118 @@ namespace std {
 
 // [reduce]
 
-template<class ExecutionPolicy, class InputIterator, class T, class BinaryOperation>
+template<class ExecutionPolicy, class ForwardIterator, class T, class BinaryOperation>
 pstl::internal::enable_if_execution_policy<ExecutionPolicy,T>
-reduce(ExecutionPolicy&& exec, InputIterator first, InputIterator last, T init, BinaryOperation binary_op) {
+reduce(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, T init, BinaryOperation binary_op) {
     return transform_reduce(std::forward<ExecutionPolicy>(exec), first, last, init, binary_op, pstl::internal::no_op());
 }
 
-template<class ExecutionPolicy, class InputIterator, class T>
+template<class ExecutionPolicy, class ForwardIterator, class T>
 pstl::internal::enable_if_execution_policy<ExecutionPolicy,T>
-reduce(ExecutionPolicy&& exec, InputIterator first, InputIterator last, T init) {
+reduce(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, T init) {
     return transform_reduce(std::forward<ExecutionPolicy>(exec), first, last, init, std::plus<T>(), pstl::internal::no_op());
 }
 
-template<class ExecutionPolicy, class InputIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,typename iterator_traits<InputIterator>::value_type>
-reduce(ExecutionPolicy&& exec, InputIterator first, InputIterator last) {
-    typedef typename iterator_traits<InputIterator>::value_type T;
+template<class ExecutionPolicy, class ForwardIterator>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy,typename iterator_traits<ForwardIterator>::value_type>
+reduce(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last) {
+    typedef typename iterator_traits<ForwardIterator>::value_type T;
     return transform_reduce(std::forward<ExecutionPolicy>(exec), first, last, T{}, std::plus<T>(), pstl::internal::no_op());
 }
 
 // [transform.reduce]
 
-template <class ExecutionPolicy, class InputIterator1, class InputIterator2, class T>
+template <class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class T>
 pstl::internal::enable_if_execution_policy<ExecutionPolicy, T>
-transform_reduce(ExecutionPolicy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, T init) {
-    typedef typename iterator_traits<InputIterator1>::value_type input_type;
+transform_reduce(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, T init) {
+    typedef typename iterator_traits<ForwardIterator1>::value_type input_type;
     using namespace pstl::internal;
     return pattern_transform_reduce(first1, last1, first2, init, std::plus<T>(), std::multiplies<input_type>(),
-        is_vectorization_preferred<ExecutionPolicy, InputIterator1, InputIterator2>(exec),
-        is_parallelization_preferred<ExecutionPolicy, InputIterator1, InputIterator2>(exec));
+        is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec),
+        is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec));
 }
 
-template <class ExecutionPolicy, class InputIterator1, class InputIterator2, class T, class BinaryOperation1, class BinaryOperation2>
+template <class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class T, class BinaryOperation1, class BinaryOperation2>
 pstl::internal::enable_if_execution_policy<ExecutionPolicy, T>
-transform_reduce(ExecutionPolicy&& exec, InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, T init, BinaryOperation1 binary_op1, BinaryOperation2 binary_op2) {
+transform_reduce(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, T init, BinaryOperation1 binary_op1, BinaryOperation2 binary_op2) {
     using namespace pstl::internal;
     return pattern_transform_reduce(first1, last1, first2, init, binary_op1, binary_op2,
-        is_vectorization_preferred<ExecutionPolicy, InputIterator1, InputIterator2>(exec),
-        is_parallelization_preferred<ExecutionPolicy, InputIterator1, InputIterator2>(exec));
+        is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec),
+        is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec));
 }
 
-template<class ExecutionPolicy, class InputIterator, class T, class BinaryOperation, class UnaryOperation>
+template<class ExecutionPolicy, class ForwardIterator, class T, class BinaryOperation, class UnaryOperation>
 pstl::internal::enable_if_execution_policy<ExecutionPolicy,T>
-transform_reduce(ExecutionPolicy&& exec, InputIterator first, InputIterator last, T init, BinaryOperation binary_op, UnaryOperation unary_op) {
+transform_reduce(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, T init, BinaryOperation binary_op, UnaryOperation unary_op) {
     using namespace pstl::internal;
     return pattern_transform_reduce(first, last, init, binary_op, unary_op,
-        is_vectorization_preferred<ExecutionPolicy,InputIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy,InputIterator>(exec));
+        is_vectorization_preferred<ExecutionPolicy,ForwardIterator>(exec),
+        is_parallelization_preferred<ExecutionPolicy,ForwardIterator>(exec));
 }
 
 // [exclusive.scan]
 
-template<class ExecutionPolicy, class InputIterator, class OutputIterator, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,OutputIterator>
-exclusive_scan(ExecutionPolicy&& exec, InputIterator first, InputIterator last, OutputIterator result, T init) {
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class T>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
+exclusive_scan(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, T init) {
     return transform_exclusive_scan(std::forward<ExecutionPolicy>(exec), first, last, result, init, std::plus<T>(), pstl::internal::no_op());
 }
 
-template<class ExecutionPolicy, class InputIterator, class OutputIterator, class T, class BinaryOperation>
-OutputIterator exclusive_scan(ExecutionPolicy&& exec, InputIterator first, InputIterator last, OutputIterator result, T init, BinaryOperation binary_op) {
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class T, class BinaryOperation>
+ForwardIterator2 exclusive_scan(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, T init, BinaryOperation binary_op) {
     return transform_exclusive_scan(std::forward<ExecutionPolicy>(exec), first, last, result, init, binary_op, pstl::internal::no_op());
 }
 
 // [inclusive.scan]
 
-template<class ExecutionPolicy, class InputIterator, class OutputIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,OutputIterator>
-inclusive_scan(ExecutionPolicy&& exec, InputIterator first, InputIterator last, OutputIterator result) {
-    typedef typename iterator_traits<InputIterator>::value_type input_type;
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
+inclusive_scan(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result) {
+    typedef typename iterator_traits<ForwardIterator1>::value_type input_type;
     return transform_inclusive_scan(std::forward<ExecutionPolicy>(exec), first, last, result, std::plus<input_type>(), pstl::internal::no_op());
 }
 
-template<class ExecutionPolicy, class InputIterator, class OutputIterator, class BinaryOperation>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,OutputIterator>
-inclusive_scan(ExecutionPolicy&& exec, InputIterator first, InputIterator last, OutputIterator result, BinaryOperation binary_op) {
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class BinaryOperation>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
+inclusive_scan(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, BinaryOperation binary_op) {
     return transform_inclusive_scan(std::forward<ExecutionPolicy>(exec), first, last, result, binary_op, pstl::internal::no_op());
 }
 
-template<class ExecutionPolicy, class InputIterator, class OutputIterator, class T, class BinaryOperation>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,OutputIterator>
-inclusive_scan(ExecutionPolicy&& exec, InputIterator first, InputIterator last, OutputIterator result, BinaryOperation binary_op, T init) {
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class T, class BinaryOperation>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
+inclusive_scan(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, BinaryOperation binary_op, T init) {
     return transform_inclusive_scan(std::forward<ExecutionPolicy>(exec), first, last, result, binary_op, pstl::internal::no_op(), init);
 }
 
 // [transform.exclusive.scan]
 
-template<class ExecutionPolicy, class InputIterator, class OutputIterator, class T, class BinaryOperation, class UnaryOperation>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,OutputIterator>
-transform_exclusive_scan(ExecutionPolicy&& exec, InputIterator first, InputIterator last, OutputIterator result, T init, BinaryOperation binary_op, UnaryOperation unary_op) {
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class T, class BinaryOperation, class UnaryOperation>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
+transform_exclusive_scan(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, T init, BinaryOperation binary_op, UnaryOperation unary_op) {
     using namespace pstl::internal;
     return pattern_transform_scan(
         first, last, result, unary_op, init, binary_op,
         /*inclusive=*/std::false_type(),
-        is_vectorization_preferred<ExecutionPolicy,InputIterator,OutputIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy,InputIterator,OutputIterator>(exec));
+        is_vectorization_preferred<ExecutionPolicy,ForwardIterator1,ForwardIterator2>(exec),
+        is_parallelization_preferred<ExecutionPolicy,ForwardIterator1,ForwardIterator2>(exec));
 }
 
 // [transform.inclusive.scan]
 
-template<class ExecutionPolicy, class InputIterator, class OutputIterator, class BinaryOperation, class UnaryOperation, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,OutputIterator>
-transform_inclusive_scan(ExecutionPolicy&& exec, InputIterator first, InputIterator last, OutputIterator result, BinaryOperation binary_op, UnaryOperation unary_op, T init) {
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class BinaryOperation, class UnaryOperation, class T>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
+transform_inclusive_scan(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, BinaryOperation binary_op, UnaryOperation unary_op, T init) {
     using namespace pstl::internal;
     return pattern_transform_scan(
         first, last, result, unary_op, init, binary_op,
         /*inclusive=*/std::true_type(),
-        is_vectorization_preferred<ExecutionPolicy,InputIterator,OutputIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy,InputIterator,OutputIterator>(exec));
+        is_vectorization_preferred<ExecutionPolicy,ForwardIterator1,ForwardIterator2>(exec),
+        is_parallelization_preferred<ExecutionPolicy,ForwardIterator1,ForwardIterator2>(exec));
 }
 
-template<class ExecutionPolicy, class InputIterator, class OutputIterator, class UnaryOperation, class BinaryOperation>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,OutputIterator>
-transform_inclusive_scan(ExecutionPolicy&& exec,  InputIterator first, InputIterator last, OutputIterator result, BinaryOperation binary_op, UnaryOperation unary_op) {
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class UnaryOperation, class BinaryOperation>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
+transform_inclusive_scan(ExecutionPolicy&& exec,  ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, BinaryOperation binary_op, UnaryOperation unary_op) {
     if( first!=last ) {
         auto tmp = unary_op(*first);
         *result = tmp;
@@ -154,19 +156,19 @@ transform_inclusive_scan(ExecutionPolicy&& exec,  InputIterator first, InputIter
 
 // [adjacent.difference]
 
-template<class ExecutionPolicy, class InputIterator, class OutputIterator, class BinaryOperation>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, OutputIterator>
-adjacent_difference(ExecutionPolicy&& exec, InputIterator first, InputIterator last, OutputIterator d_first, BinaryOperation op) {
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class BinaryOperation>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator2>
+adjacent_difference(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 d_first, BinaryOperation op) {
     using namespace pstl::internal;
     return pattern_adjacent_difference(first, last, d_first, op,
-        is_vectorization_preferred<ExecutionPolicy, InputIterator, OutputIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy, InputIterator, OutputIterator>(exec));
+        is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec),
+        is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec));
 }
 
-template<class ExecutionPolicy, class InputIterator, class OutputIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, OutputIterator>
-adjacent_difference(ExecutionPolicy&& exec, InputIterator first, InputIterator last, OutputIterator d_first) {
-    typedef typename iterator_traits<InputIterator>::value_type value_type;
+template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
+pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator2>
+adjacent_difference(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 d_first) {
+    typedef typename iterator_traits<ForwardIterator1>::value_type value_type;
     return adjacent_difference(std::forward<ExecutionPolicy>(exec), first, last, d_first, std::minus<value_type>());
 }
 


### PR DESCRIPTION
https://wg21.link/n4700 changed most of the parallel algorithms from InputIterator to ForwardIterator requirements. This change renames the template parameters to match this change.