### PR TITLE
Initial pass "hardening" against macro and ADL issues

### DIFF
--- a/include/pstl/internal/algorithm_impl.h
+++ b/include/pstl/internal/algorithm_impl.h
@@ -149,17 +149,17 @@ void brick_it_walk1( _RandomAccessIterator __first, _RandomAccessIterator __last
     unseq_backend::simd_it_walk_1(__first, __last - __first, __f);
 }
 
-template<class __ForwardIterator, class _Function, class _IsVector>
-void pattern_it_walk1( __ForwardIterator __first, __ForwardIterator __last, _Function __f, _IsVector __is_vector,
+template<class _ForwardIterator, class _Function, class _IsVector>
+void pattern_it_walk1( _ForwardIterator __first, _ForwardIterator __last, _Function __f, _IsVector __is_vector,
                        /*parallel=*/std::false_type ) noexcept {
     internal::brick_it_walk1( __first, __last, __f, __is_vector );
 }
 
-template<class __ForwardIterator, class _Function, class _IsVector>
-void pattern_it_walk1( __ForwardIterator __first, __ForwardIterator __last, _Function __f, _IsVector __is_vector,
+template<class _ForwardIterator, class _Function, class _IsVector>
+void pattern_it_walk1( _ForwardIterator __first, _ForwardIterator __last, _Function __f, _IsVector __is_vector,
                        /*parallel=*/std::true_type ) {
     internal::except_handler([=]() {
-        par_backend::parallel_for( __first, __last, [__f,__is_vector](__ForwardIterator __i, __ForwardIterator __j) {
+        par_backend::parallel_for( __first, __last, [__f,__is_vector](_ForwardIterator __i, _ForwardIterator __j) {
             internal::brick_it_walk1( __i, __j, __f, __is_vector );
         });
     });
@@ -168,64 +168,64 @@ void pattern_it_walk1( __ForwardIterator __first, __ForwardIterator __last, _Fun
 //------------------------------------------------------------------------
 // walk1_n
 //------------------------------------------------------------------------
-template<class InputIterator, class _Size, class _Function>
-InputIterator brick_walk1_n(InputIterator __first, _Size __n, _Function __f, /*_IsVectorTag=*/std::false_type ) {
+template<class _ForwardIterator, class _Size, class _Function>
+_ForwardIterator brick_walk1_n(_ForwardIterator __first, _Size __n, _Function __f, /*_IsVectorTag=*/std::false_type ) {
     return internal::for_each_n( __first, __n, __f ); // calling serial version
 }
 
-template<class RandomAccessIterator, class _DifferenceType, class _Function>
-RandomAccessIterator brick_walk1_n( RandomAccessIterator __first, _DifferenceType __n, _Function __f,
+template<class _RandomAccessIterator, class _DifferenceType, class _Function>
+_RandomAccessIterator brick_walk1_n( _RandomAccessIterator __first, _DifferenceType __n, _Function __f,
                                     /*vectorTag=*/std::true_type ) noexcept {
     return unseq_backend::simd_walk_1(__first, __n, __f);
 }
 
-template<class InputIterator, class _Size, class _Function, class _IsVector>
-InputIterator pattern_walk1_n( InputIterator __first, _Size __n, _Function __f, _IsVector __is_vector,
+template<class _ForwardIterator, class _Size, class _Function, class _IsVector>
+_ForwardIterator pattern_walk1_n( _ForwardIterator __first, _Size __n, _Function __f, _IsVector __is_vector,
                                /*is_parallel=*/std::false_type ) noexcept {
     return internal::brick_walk1_n(__first, __n, __f, __is_vector);
 }
 
-template<class RandomAccessIterator, class _Size, class _Function, class _IsVector>
-RandomAccessIterator pattern_walk1_n( RandomAccessIterator __first, _Size __n, _Function __f, _IsVector __is_vector,
+template<class _RandomAccessIterator, class _Size, class _Function, class _IsVector>
+_RandomAccessIterator pattern_walk1_n( _RandomAccessIterator __first, _Size __n, _Function __f, _IsVector __is_vector,
                                       /*is_parallel=*/std::true_type ) {
     internal::pattern_walk1(__first, __first + __n, __f, __is_vector, std::true_type());
     return __first + __n;
 }
 
-template<class InputIterator, class _Size, class _Brick>
-InputIterator pattern_walk_brick_n( InputIterator __first, _Size __n, _Brick __brick, /*is_parallel=*/std::false_type ) noexcept {
+template<class _ForwardIterator, class _Size, class _Brick>
+_ForwardIterator pattern_walk_brick_n( _ForwardIterator __first, _Size __n, _Brick __brick, /*is_parallel=*/std::false_type ) noexcept {
     return __brick(__first, __n);
 }
 
-template<class RandomAccessIterator, class _Size, class _Brick>
-RandomAccessIterator pattern_walk_brick_n( RandomAccessIterator __first, _Size __n, _Brick __brick, /*is_parallel=*/std::true_type ) {
+template<class _RandomAccessIterator, class _Size, class _Brick>
+_RandomAccessIterator pattern_walk_brick_n( _RandomAccessIterator __first, _Size __n, _Brick __brick, /*is_parallel=*/std::true_type ) {
     return internal::except_handler([=]() {
-        par_backend::parallel_for(__first, __first + __n, [__brick](RandomAccessIterator __i, RandomAccessIterator __j) {
+        par_backend::parallel_for(__first, __first + __n, [__brick](_RandomAccessIterator __i, _RandomAccessIterator __j) {
             __brick(__i, __j - __i);
         });
         return __first + __n;
     });
 }
 
-template<class InputIterator, class _Size, class _Function>
-InputIterator brick_it_walk1_n(InputIterator __first, _Size __n, _Function __f, /*_IsVectorTag=*/std::false_type ) {
+template<class _ForwardIterator, class _Size, class _Function>
+_ForwardIterator brick_it_walk1_n(_ForwardIterator __first, _Size __n, _Function __f, /*_IsVectorTag=*/std::false_type ) {
     return internal::for_each_n_serial(__first, __n, __f); // calling serial version
 }
 
-template<class RandomAccessIterator, class _DifferenceType, class _Function>
-RandomAccessIterator brick_it_walk1_n( RandomAccessIterator __first, _DifferenceType __n, _Function __f,
+template<class _RandomAccessIterator, class _DifferenceType, class _Function>
+_RandomAccessIterator brick_it_walk1_n( _RandomAccessIterator __first, _DifferenceType __n, _Function __f,
                                        /*vectorTag=*/std::true_type ) noexcept {
     return unseq_backend::simd_it_walk_1(__first, __n, __f);
 }
 
-template<class InputIterator, class _Size, class _Function, class _IsVector>
-InputIterator pattern_it_walk1_n( InputIterator __first, _Size __n, _Function __f, _IsVector __is_vector,
+template<class _ForwardIterator, class _Size, class _Function, class _IsVector>
+_ForwardIterator pattern_it_walk1_n( _ForwardIterator __first, _Size __n, _Function __f, _IsVector __is_vector,
                                   /*is_parallel=*/std::false_type ) noexcept {
     return internal::brick_it_walk1_n(__first, __n, __f, __is_vector);
 }
 
-template<class RandomAccessIterator, class _Size, class _Function, class _IsVector>
-RandomAccessIterator pattern_it_walk1_n( RandomAccessIterator __first, _Size __n, _Function __f,
+template<class _RandomAccessIterator, class _Size, class _Function, class _IsVector>
+_RandomAccessIterator pattern_it_walk1_n( _RandomAccessIterator __first, _Size __n, _Function __f,
                                          _IsVector __is_vector, /*is_parallel=*/std::true_type ) {
     internal::pattern_it_walk1(__first, __first + __n, __f, __is_vector, std::true_type());
     return __first + __n;
@@ -284,14 +284,14 @@ _ForwardIterator2 pattern_walk2(_ForwardIterator1 __first1, _ForwardIterator1 __
     });
 }
 
-template<class _ForwardIterator1, class _Size, class _ForwardIterator2, class Function, class IsVector>
-_ForwardIterator2 pattern_walk2_n( _ForwardIterator1 __first1, _Size n, _ForwardIterator2 __first2, Function f,
-                                   IsVector is_vector, /*parallel=*/std::false_type ) noexcept {
+template<class _ForwardIterator1, class _Size, class _ForwardIterator2, class _Function, class _IsVector>
+_ForwardIterator2 pattern_walk2_n( _ForwardIterator1 __first1, _Size n, _ForwardIterator2 __first2, _Function f,
+                                   _IsVector is_vector, /*parallel=*/std::false_type ) noexcept {
     return internal::brick_walk2_n(__first1, n, __first2, f, is_vector);
 }
 
-template<class _RandomAccessIterator1, class _Size, class _RandomAccessIterator2, class Function, class IsVector>
-_RandomAccessIterator2 pattern_walk2_n(_RandomAccessIterator1 __first1, _Size n, _RandomAccessIterator2 __first2, Function f, IsVector is_vector, /*parallel=*/std::true_type ) {
+template<class _RandomAccessIterator1, class _Size, class _RandomAccessIterator2, class _Function, class _IsVector>
+_RandomAccessIterator2 pattern_walk2_n(_RandomAccessIterator1 __first1, _Size n, _RandomAccessIterator2 __first2, _Function f, _IsVector is_vector, /*parallel=*/std::true_type ) {
     return internal::pattern_walk2(__first1, __first1 + n, __first2, f, is_vector, std::true_type());
 }
 
@@ -395,8 +395,8 @@ _ForwardIterator2 pattern_it_walk2_n(_ForwardIterator1 __first1, _Size __n, _For
 // walk3 evaluates f(x,y,z) for (x,y,z) drawn from [first1,last1), [first2,...), [first3,...)
 //------------------------------------------------------------------------
 template<class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator3, class _Function>
-_ForwardIterator3 brick_walk3( _ForwardIterator1 __first1, _ForwardIterator1 last1, _ForwardIterator2 __first2, _ForwardIterator3 __first3, _Function __f, /*vector=*/std::false_type ) noexcept {
-    for(; __first1!=last1; ++__first1, ++__first2, ++__first3 )
+_ForwardIterator3 brick_walk3( _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator3 __first3, _Function __f, /*vector=*/std::false_type ) noexcept {
+    for(; __first1!=__last1; ++__first1, ++__first2, ++__first3 )
         __f(*__first1, *__first2, *__first3);
     return __first3;
 }
@@ -753,8 +753,8 @@ OutputIterator brick_copy_if(_ForwardIterator __first, _ForwardIterator __last, 
     return std::copy_if(__first, __last, __result, __pred);
 }
 
-template<class _ForwardIterator, class OutputIterator, class _UnaryPredicate>
-OutputIterator brick_copy_if(_ForwardIterator __first, _ForwardIterator __last, OutputIterator __result, _UnaryPredicate __pred, /*vector=*/std::true_type) noexcept {
+template<class _ForwardIterator, class _OutputIterator, class _UnaryPredicate>
+_OutputIterator brick_copy_if(_ForwardIterator __first, _ForwardIterator __last, _OutputIterator __result, _UnaryPredicate __pred, /*vector=*/std::true_type) noexcept {
 #if (__PSTL_MONOTONIC_PRESENT)
     return unseq_backend::simd_copy_if(__first, __last - __first, __result, __pred);
 #else
@@ -865,7 +865,7 @@ _OutputIterator pattern_copy_if(_RandomAccessIterator __first, _RandomAccessIter
             });
         }
     }
-    // _Out of memory or trivial sequence - use serial algorithm
+    // Out of memory or trivial sequence - use serial algorithm
     return brick_copy_if(__first, __last, __result, __pred, __is_vector);
 }
 
@@ -1464,8 +1464,8 @@ void pattern_fill(_ForwardIterator __first, _ForwardIterator __last, const _Tp& 
     internal::brick_fill(__first, __last, __value, __is_vector);
 }
 
-template<class _ForwardIterator, class T, class _IsVector>
-_ForwardIterator pattern_fill(_ForwardIterator __first, _ForwardIterator __last, const T& __value, /*is_parallel=*/std::true_type, _IsVector __is_vector) {
+template<class _ForwardIterator, class _Tp, class _IsVector>
+_ForwardIterator pattern_fill(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value, /*is_parallel=*/std::true_type, _IsVector __is_vector) {
     return except_handler([__first, __last, &__value, __is_vector]() {
         par_backend::parallel_for(__first, __last, [&__value, __is_vector](_ForwardIterator __begin, _ForwardIterator __end) {
             internal::brick_fill(__begin, __end, __value, __is_vector); });
@@ -1622,24 +1622,24 @@ void pattern_inplace_merge(_BidirectionalIterator __first, _BidirectionalIterato
 // includes
 //------------------------------------------------------------------------
 
-template<class ForwardIterator1, class ForwardIterator2, class _Compare>
-bool brick_includes(ForwardIterator1 __first1, ForwardIterator1 __last1, ForwardIterator2 __first2, ForwardIterator2 __last2, _Compare __comp, /* _IsVector = */ std::false_type) noexcept {
+template<class _ForwardIterator1, class _ForwardIterator2, class _Compare>
+bool brick_includes(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2, _Compare __comp, /* _IsVector = */ std::false_type) noexcept {
     return std::includes(__first1, __last1, __first2, __last2, __comp);
 }
 
-template<class ForwardIterator1, class ForwardIterator2, class _Compare>
-bool brick_includes(ForwardIterator1 __first1, ForwardIterator1 __last1, ForwardIterator2 __first2, ForwardIterator2 __last2, _Compare __comp, /* _IsVector = */ std::true_type) noexcept {
+template<class _ForwardIterator1, class _ForwardIterator2, class _Compare>
+bool brick_includes(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2, _Compare __comp, /* _IsVector = */ std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial")
         return std::includes(__first1, __last1, __first2, __last2, __comp);
 }
 
-template<class ForwardIterator1, class ForwardIterator2, class _Compare, class _IsVector>
-bool pattern_includes(ForwardIterator1 __first1, ForwardIterator1 __last1, ForwardIterator2 __first2, ForwardIterator2 __last2, _Compare __comp, _IsVector __is_vector, /*is_parallel=*/std::false_type) noexcept {
+template<class _ForwardIterator1, class _ForwardIterator2, class _Compare, class _IsVector>
+bool pattern_includes(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2, _Compare __comp, _IsVector __is_vector, /*is_parallel=*/std::false_type) noexcept {
     return internal::brick_includes(__first1, __last1, __first2, __last2, __comp, __is_vector);
 }
 
-template<class ForwardIterator1, class ForwardIterator2, class _Compare, class _IsVector>
-bool pattern_includes(ForwardIterator1 __first1, ForwardIterator1 __last1, ForwardIterator2 __first2, ForwardIterator2 __last2, _Compare __comp, _IsVector __is_vector, /*is_parallel=*/std::true_type) noexcept {
+template<class _ForwardIterator1, class _ForwardIterator2, class _Compare, class _IsVector>
+bool pattern_includes(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2, _Compare __comp, _IsVector __is_vector, /*is_parallel=*/std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Parallel algorithm unimplemented, redirected to serial");
     return internal::brick_includes(__first1, __last1, __first2, __last2, __comp, __is_vector);
 }

--- a/include/pstl/internal/algorithm_impl.h
+++ b/include/pstl/internal/algorithm_impl.h
@@ -35,34 +35,37 @@
 #endif
 #include "parallel_impl.h"
 
-namespace pstl {
+namespace __pstl {
 namespace internal {
 
 //------------------------------------------------------------------------
 // any_of
 //------------------------------------------------------------------------
 
-template<class InputIterator, class Pred>
-bool brick_any_of( const InputIterator first, const InputIterator last, Pred pred, /*is_vector=*/std::false_type ) noexcept {
-    return std::any_of(first,last,pred);
+template<class _ForwardIterator, class _Pred>
+bool brick_any_of( const _ForwardIterator __first, const _ForwardIterator __last, _Pred __pred, /*__is_vector=*/std::false_type ) noexcept {
+    return std::any_of( __first, __last, __pred );
 };
 
-template<class InputIterator, class Pred>
-bool brick_any_of( const InputIterator first, const InputIterator last, Pred pred, /*is_vector=*/std::true_type ) noexcept {
-    return unseq_backend::simd_or( first, last-first, pred );
+template<class _ForwardIterator, class _Pred>
+bool brick_any_of( const _ForwardIterator __first, const _ForwardIterator __last, _Pred __pred, /*__is_vector=*/std::true_type ) noexcept {
+    return unseq_backend::simd_or( __first, __last - __first, __pred );
 };
 
 
-template<class InputIterator, class Pred, class IsVector>
-bool pattern_any_of( InputIterator first, InputIterator last, Pred pred, IsVector is_vector, /*parallel=*/std::false_type ) noexcept {
-    return brick_any_of(first,last,pred,is_vector);
+template<class _ForwardIterator, class _Pred, class _IsVector>
+bool pattern_any_of( _ForwardIterator __first, _ForwardIterator __last, _Pred __pred, _IsVector __is_vector, /*parallel=*/std::false_type ) noexcept {
+  return internal::brick_any_of( __first, __last, __pred, __is_vector);
 }
 
-template<class InputIterator, class Pred, class IsVector>
-bool pattern_any_of( InputIterator first, InputIterator last, Pred pred, IsVector is_vector, /*parallel=*/std::true_type ) {
-    return except_handler([=]() {
-        return internal::parallel_or( first, last,
-            [pred, is_vector](InputIterator i, InputIterator j) {return brick_any_of(i, j, pred, is_vector);} );
+template<class _ForwardIterator, class _Pred, class _IsVector>
+bool pattern_any_of( _ForwardIterator __first, _ForwardIterator __last, _Pred __pred, _IsVector __is_vector, /*parallel=*/std::true_type ) {
+    return internal::except_handler([=]() {
+        return internal::parallel_or( __first, __last,
+            [__pred, __is_vector]( _ForwardIterator __i, _ForwardIterator __j)
+                                 {
+                                     return internal::brick_any_of(__i, __j, __pred, __is_vector);
+                                 } );
     });
 }
 
@@ -70,16 +73,16 @@ bool pattern_any_of( InputIterator first, InputIterator last, Pred pred, IsVecto
 // [alg.foreach]
 // for_each_n with no policy
 
-template<class InputIterator, class Size, class Function>
-InputIterator for_each_n_serial(InputIterator first, Size n, Function f) {
-    for(; n > 0; ++first, --n)
-        f(first);
-    return first;
+template<class _ForwardIterator, class _Size, class _Function>
+_ForwardIterator for_each_n_serial(_ForwardIterator __first, _Size __n, _Function __f) {
+    for(; __n > 0; ++__first, --__n)
+        __f(__first);
+    return __first;
 }
 
-template<class InputIterator, class Size, class Function>
-InputIterator for_each_n(InputIterator first, Size n, Function f) {
-    return for_each_n_serial(first, n, [&f](InputIterator it) { f(*it); });
+template<class _ForwardIterator, class _Size, class _Function>
+_ForwardIterator for_each_n(_ForwardIterator __first, _Size __n, _Function __f) {
+    return internal::for_each_n_serial(__first, __n, [&__f](_ForwardIterator __it) { __f(*__it); });
 }
 
 //------------------------------------------------------------------------
@@ -87,42 +90,44 @@ InputIterator for_each_n(InputIterator first, Size n, Function f) {
 //
 // walk1 evaluates f(x) for each dereferenced value x drawn from [first,last)
 //------------------------------------------------------------------------
-template<class Iterator, class Function>
-void brick_walk1( Iterator first, Iterator last, Function f, /*vector=*/std::false_type ) noexcept {
-    for(; first!=last; ++first )
-        f(*first);
+template<class _ForwardIterator, class _Function>
+void brick_walk1( _ForwardIterator __first, _ForwardIterator __last, _Function __f, /*vector=*/std::false_type ) noexcept {
+    for(; __first!=__last; ++__first )
+        __f(*__first);
 }
 
-template<class Iterator, class Function>
-void brick_walk1( Iterator first, Iterator last, Function f, /*vector=*/std::true_type ) noexcept {
-    unseq_backend::simd_walk_1(first, last-first, f);
+template<class _RandomAccessIterator, class _Function>
+void brick_walk1( _RandomAccessIterator __first, _RandomAccessIterator __last, _Function __f, /*vector=*/std::true_type ) noexcept {
+    unseq_backend::simd_walk_1( __first, __last - __first, __f );
 }
 
 
-template<class Iterator, class Function, class IsVector>
-void pattern_walk1( Iterator first, Iterator last, Function f, IsVector is_vector, /*parallel=*/std::false_type ) noexcept {
-    brick_walk1( first, last, f, is_vector );
+template<class _ForwardIterator, class _Function, class _IsVector>
+void pattern_walk1( _ForwardIterator __first, _ForwardIterator __last, _Function __f, _IsVector __is_vector,
+                    /*parallel=*/std::false_type ) noexcept {
+    internal::brick_walk1( __first, __last, __f, __is_vector );
 }
 
-template<class Iterator, class Function, class IsVector>
-void pattern_walk1( Iterator first, Iterator last, Function f, IsVector is_vector, /*parallel=*/std::true_type ) {
-    except_handler([=]() {
-        par_backend::parallel_for( first, last, [f,is_vector](Iterator i, Iterator j) {
-            brick_walk1(i,j,f,is_vector);
+template<class _ForwardIterator, class _Function, class _IsVector>
+void pattern_walk1( _ForwardIterator __first, _ForwardIterator __last, _Function __f, _IsVector __is_vector,
+                    /*parallel=*/std::true_type ) {
+    internal::except_handler([=]() {
+        par_backend::parallel_for( __first, __last, [__f,__is_vector](_ForwardIterator __i, _ForwardIterator __j) {
+            internal::brick_walk1( __i, __j, __f, __is_vector );
         });
     });
 }
 
-template<class Iterator, class Brick>
-void pattern_walk_brick( Iterator first, Iterator last, Brick brick, /*parallel=*/std::false_type ) noexcept {
-    brick(first, last);
+template<class _ForwardIterator, class _Brick>
+void pattern_walk_brick( _ForwardIterator __first, _ForwardIterator __last, _Brick __brick, /*parallel=*/std::false_type ) noexcept {
+    __brick(__first, __last);
 }
 
-template<class Iterator, class Brick>
-void pattern_walk_brick( Iterator first, Iterator last, Brick brick, /*parallel=*/std::true_type ) {
-    except_handler([=]() {
-        par_backend::parallel_for( first, last, [brick](Iterator i, Iterator j) {
-            brick(i,j);
+template<class _ForwardIterator, class _Brick>
+void pattern_walk_brick( _ForwardIterator __first, _ForwardIterator __last, _Brick __brick, /*parallel=*/std::true_type ) {
+    internal::except_handler([=]() {
+        par_backend::parallel_for( __first, __last, [__brick](_ForwardIterator __i, _ForwardIterator __j) {
+            __brick( __i, __j );
         });
     });
 }
@@ -133,27 +138,29 @@ void pattern_walk_brick( Iterator first, Iterator last, Brick brick, /*parallel=
 //
 // it_walk1 evaluates f(it) for each iterator it drawn from [first,last)
 //------------------------------------------------------------------------
-template<class Iterator, class Function>
-void brick_it_walk1( Iterator first, Iterator last, Function f, /*vector=*/std::false_type ) noexcept {
-    for(; first!=last; ++first )
-        f(first);
+template<class _ForwardIterator, class _Function>
+void brick_it_walk1( _ForwardIterator __first, _ForwardIterator __last, _Function __f, /*vector=*/std::false_type ) noexcept {
+    for(; __first != __last; ++__first )
+        __f(__first);
 }
 
-template<class Iterator, class Function>
-void brick_it_walk1( Iterator first, Iterator last, Function f, /*vector=*/std::true_type ) noexcept {
-    unseq_backend::simd_it_walk_1(first, last-first, f);
+template<class _RandomAccessIterator, class _Function>
+void brick_it_walk1( _RandomAccessIterator __first, _RandomAccessIterator __last, _Function __f, /*vector=*/std::true_type ) noexcept {
+    unseq_backend::simd_it_walk_1(__first, __last - __first, __f);
 }
 
-template<class Iterator, class Function, class IsVector>
-void pattern_it_walk1( Iterator first, Iterator last, Function f, IsVector is_vector, /*parallel=*/std::false_type ) noexcept {
-    brick_it_walk1( first, last, f, is_vector );
+template<class __ForwardIterator, class _Function, class _IsVector>
+void pattern_it_walk1( __ForwardIterator __first, __ForwardIterator __last, _Function __f, _IsVector __is_vector,
+                       /*parallel=*/std::false_type ) noexcept {
+    internal::brick_it_walk1( __first, __last, __f, __is_vector );
 }
 
-template<class Iterator, class Function, class IsVector>
-void pattern_it_walk1( Iterator first, Iterator last, Function f, IsVector is_vector, /*parallel=*/std::true_type ) {
-    except_handler([=]() {
-        par_backend::parallel_for( first, last, [f,is_vector](Iterator i, Iterator j) {
-            brick_it_walk1(i,j,f,is_vector);
+template<class __ForwardIterator, class _Function, class _IsVector>
+void pattern_it_walk1( __ForwardIterator __first, __ForwardIterator __last, _Function __f, _IsVector __is_vector,
+                       /*parallel=*/std::true_type ) {
+    internal::except_handler([=]() {
+        par_backend::parallel_for( __first, __last, [__f,__is_vector](__ForwardIterator __i, __ForwardIterator __j) {
+            internal::brick_it_walk1( __i, __j, __f, __is_vector );
         });
     });
 }
@@ -161,63 +168,67 @@ void pattern_it_walk1( Iterator first, Iterator last, Function f, IsVector is_ve
 //------------------------------------------------------------------------
 // walk1_n
 //------------------------------------------------------------------------
-template<class InputIterator, class Size, class Function>
-InputIterator brick_walk1_n(InputIterator first, Size n, Function f, /*IsVectorTag=*/std::false_type ) {
-    return internal::for_each_n( first, n, f ); // calling serial version
+template<class InputIterator, class _Size, class _Function>
+InputIterator brick_walk1_n(InputIterator __first, _Size __n, _Function __f, /*_IsVectorTag=*/std::false_type ) {
+    return internal::for_each_n( __first, __n, __f ); // calling serial version
 }
 
-template<class RandomAccessIterator, class DifferenceType, class Function>
-RandomAccessIterator brick_walk1_n( RandomAccessIterator first, DifferenceType n, Function f, /*vectorTag=*/std::true_type ) noexcept {
-    return unseq_backend::simd_walk_1(first, n, f);
+template<class RandomAccessIterator, class _DifferenceType, class _Function>
+RandomAccessIterator brick_walk1_n( RandomAccessIterator __first, _DifferenceType __n, _Function __f,
+                                    /*vectorTag=*/std::true_type ) noexcept {
+    return unseq_backend::simd_walk_1(__first, __n, __f);
 }
 
-template<class InputIterator, class Size, class Function, class IsVector>
-InputIterator pattern_walk1_n( InputIterator first, Size n, Function f, IsVector is_vector, /*is_parallel=*/std::false_type ) noexcept {
-    return brick_walk1_n(first, n, f, is_vector);
+template<class InputIterator, class _Size, class _Function, class _IsVector>
+InputIterator pattern_walk1_n( InputIterator __first, _Size __n, _Function __f, _IsVector __is_vector,
+                               /*is_parallel=*/std::false_type ) noexcept {
+    return internal::brick_walk1_n(__first, __n, __f, __is_vector);
 }
 
-template<class RandomAccessIterator, class Size, class Function, class IsVector>
-RandomAccessIterator pattern_walk1_n( RandomAccessIterator first, Size n, Function f, IsVector is_vector, /*is_parallel=*/std::true_type ) {
-    pattern_walk1(first, first + n, f, is_vector, std::true_type());
-    return first + n;
+template<class RandomAccessIterator, class _Size, class _Function, class _IsVector>
+RandomAccessIterator pattern_walk1_n( RandomAccessIterator __first, _Size __n, _Function __f, _IsVector __is_vector,
+                                      /*is_parallel=*/std::true_type ) {
+    internal::pattern_walk1(__first, __first + __n, __f, __is_vector, std::true_type());
+    return __first + __n;
 }
 
-template<class InputIterator, class Size, class Brick>
-InputIterator pattern_walk_brick_n( InputIterator first, Size n, Brick brick, /*is_parallel=*/std::false_type ) noexcept {
-    return brick(first, n);
+template<class InputIterator, class _Size, class _Brick>
+InputIterator pattern_walk_brick_n( InputIterator __first, _Size __n, _Brick __brick, /*is_parallel=*/std::false_type ) noexcept {
+    return __brick(__first, __n);
 }
 
-template<class RandomAccessIterator, class Size, class Brick>
-RandomAccessIterator pattern_walk_brick_n( RandomAccessIterator first, Size n, Brick brick, /*is_parallel=*/std::true_type ) {
-    return except_handler([=]() {
-        par_backend::parallel_for(first, first + n, [brick](RandomAccessIterator i, RandomAccessIterator j) {
-            brick(i, j-i);
+template<class RandomAccessIterator, class _Size, class _Brick>
+RandomAccessIterator pattern_walk_brick_n( RandomAccessIterator __first, _Size __n, _Brick __brick, /*is_parallel=*/std::true_type ) {
+    return internal::except_handler([=]() {
+        par_backend::parallel_for(__first, __first + __n, [__brick](RandomAccessIterator __i, RandomAccessIterator __j) {
+            __brick(__i, __j - __i);
         });
-        return first + n;
+        return __first + __n;
     });
 }
 
-
-
-template<class InputIterator, class Size, class Function>
-InputIterator brick_it_walk1_n(InputIterator first, Size n, Function f, /*IsVectorTag=*/std::false_type ) {
-    return for_each_n_serial(first, n, f); // calling serial version
+template<class InputIterator, class _Size, class _Function>
+InputIterator brick_it_walk1_n(InputIterator __first, _Size __n, _Function __f, /*_IsVectorTag=*/std::false_type ) {
+    return internal::for_each_n_serial(__first, __n, __f); // calling serial version
 }
 
-template<class RandomAccessIterator, class DifferenceType, class Function>
-RandomAccessIterator brick_it_walk1_n( RandomAccessIterator first, DifferenceType n, Function f, /*vectorTag=*/std::true_type ) noexcept {
-    return unseq_backend::simd_it_walk_1(first, n, f);
+template<class RandomAccessIterator, class _DifferenceType, class _Function>
+RandomAccessIterator brick_it_walk1_n( RandomAccessIterator __first, _DifferenceType __n, _Function __f,
+                                       /*vectorTag=*/std::true_type ) noexcept {
+    return unseq_backend::simd_it_walk_1(__first, __n, __f);
 }
 
-template<class InputIterator, class Size, class Function, class IsVector>
-InputIterator pattern_it_walk1_n( InputIterator first, Size n, Function f, IsVector is_vector, /*is_parallel=*/std::false_type ) noexcept {
-    return brick_it_walk1_n(first, n, f, is_vector);
+template<class InputIterator, class _Size, class _Function, class _IsVector>
+InputIterator pattern_it_walk1_n( InputIterator __first, _Size __n, _Function __f, _IsVector __is_vector,
+                                  /*is_parallel=*/std::false_type ) noexcept {
+    return internal::brick_it_walk1_n(__first, __n, __f, __is_vector);
 }
 
-template<class RandomAccessIterator, class Size, class Function, class IsVector>
-RandomAccessIterator pattern_it_walk1_n( RandomAccessIterator first, Size n, Function f, IsVector is_vector, /*is_parallel=*/std::true_type ) {
-    pattern_it_walk1(first, first + n, f, is_vector, std::true_type());
-    return first + n;
+template<class RandomAccessIterator, class _Size, class _Function, class _IsVector>
+RandomAccessIterator pattern_it_walk1_n( RandomAccessIterator __first, _Size __n, _Function __f,
+                                         _IsVector __is_vector, /*is_parallel=*/std::true_type ) {
+    internal::pattern_it_walk1(__first, __first + __n, __f, __is_vector, std::true_type());
+    return __first + __n;
 }
 
 //------------------------------------------------------------------------
@@ -225,94 +236,99 @@ RandomAccessIterator pattern_it_walk1_n( RandomAccessIterator first, Size n, Fun
 //
 // walk2 evaluates f(x,y) for deferenced values (x,y) drawn from [first1,last1) and [first2,...)
 //------------------------------------------------------------------------
-template<class Iterator1, class Iterator2, class Function>
-Iterator2 brick_walk2( Iterator1 first1, Iterator1 last1, Iterator2 first2, Function f, /*vector=*/std::false_type ) noexcept {
-    for(; first1!=last1; ++first1, ++first2 )
-        f(*first1, *first2);
-    return first2;
+template<class _ForwardIterator1, class _ForwardIterator2, class _Function>
+_ForwardIterator2 brick_walk2( _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _Function __f,
+                               /*vector=*/std::false_type ) noexcept {
+    for(; __first1 != __last1; ++__first1, ++__first2 )
+        __f(*__first1, *__first2);
+    return __first2;
 }
 
-template<class Iterator1, class Iterator2, class Function>
-Iterator2 brick_walk2( Iterator1 first1, Iterator1 last1, Iterator2 first2, Function f, /*vector=*/std::true_type) noexcept {
-    return unseq_backend::simd_walk_2(first1, last1-first1, first2, f);
+template<class _ForwardIterator1, class _ForwardIterator2, class _Function>
+_ForwardIterator2 brick_walk2( _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _Function __f,
+                               /*vector=*/std::true_type) noexcept {
+    return unseq_backend::simd_walk_2(__first1, __last1 - __first1, __first2, __f);
 }
 
-template<class Iterator1, class Size, class Iterator2, class Function>
-Iterator2 brick_walk2_n( Iterator1 first1, Size n, Iterator2 first2, Function f, /*vector=*/std::false_type ) noexcept {
-    for(; n > 0; --n, ++first1, ++first2 )
-        f(*first1, *first2);
-    return first2;
+template<class _ForwardIterator1, class _Size, class _ForwardIterator2, class _Function>
+_ForwardIterator2 brick_walk2_n( _ForwardIterator1 __first1, _Size __n, _ForwardIterator2 __first2, _Function __f,
+                                 /*vector=*/std::false_type ) noexcept {
+    for(; __n > 0; --__n, ++__first1, ++__first2 )
+        __f(*__first1, *__first2);
+    return __first2;
 }
 
-template<class Iterator1, class Size, class Iterator2, class Function>
-Iterator2 brick_walk2_n(Iterator1 first1, Size n, Iterator2 first2, Function f, /*vector=*/std::true_type) noexcept {
-    return unseq_backend::simd_walk_2(first1, n, first2, f);
+template<class _ForwardIterator1, class _Size, class _ForwardIterator2, class _Function>
+_ForwardIterator2 brick_walk2_n(_ForwardIterator1 __first1, _Size __n, _ForwardIterator2 __first2, _Function __f,
+                                /*vector=*/std::true_type) noexcept {
+    return unseq_backend::simd_walk_2(__first1, __n, __first2, __f);
 }
 
-
-
-template<class Iterator1, class Iterator2, class Function, class IsVector>
-Iterator2 pattern_walk2( Iterator1 first1, Iterator1 last1, Iterator2 first2, Function f, IsVector is_vector, /*parallel=*/std::false_type ) noexcept {
-    return brick_walk2(first1,last1,first2,f,is_vector);
+template<class _ForwardIterator1, class _ForwardIterator2, class _Function, class _IsVector>
+_ForwardIterator2 pattern_walk2( _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _Function __f,
+                                 _IsVector __is_vector, /*parallel=*/std::false_type ) noexcept {
+    return internal::brick_walk2( __first1,  __last1, __first2, __f, __is_vector );
 }
 
-template<class Iterator1, class Iterator2, class Function, class IsVector>
-Iterator2 pattern_walk2(Iterator1 first1, Iterator1 last1, Iterator2 first2, Function f, IsVector is_vector, /*parallel=*/std::true_type ) {
-    return except_handler([=]() {
+template<class _ForwardIterator1, class _ForwardIterator2, class _Function, class _IsVector>
+_ForwardIterator2 pattern_walk2(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _Function __f,
+                                _IsVector __is_vector, /*parallel=*/std::true_type ) {
+    return internal::except_handler([=]() {
         par_backend::parallel_for(
-            first1, last1,
-            [f,first1,first2,is_vector](Iterator1 i, Iterator1 j) {
-                brick_walk2(i,j,first2+(i-first1),f,is_vector);
+            __first1, __last1,
+            [__f, __first1, __first2, __is_vector](_ForwardIterator1 __i, _ForwardIterator1 __j) {
+                internal::brick_walk2(__i,__j,__first2 + (__i - __first1), __f, __is_vector);
             }
         );
-        return first2+(last1-first1);
+        return __first2 + (__last1-__first1);
     });
 }
 
-template<class Iterator1, class Size, class Iterator2, class Function, class IsVector>
-Iterator2 pattern_walk2_n( Iterator1 first1, Size n, Iterator2 first2, Function f, IsVector is_vector, /*parallel=*/std::false_type ) noexcept {
-    return brick_walk2_n(first1, n, first2, f, is_vector);
+template<class _ForwardIterator1, class _Size, class _ForwardIterator2, class Function, class IsVector>
+_ForwardIterator2 pattern_walk2_n( _ForwardIterator1 __first1, _Size n, _ForwardIterator2 __first2, Function f,
+                                   IsVector is_vector, /*parallel=*/std::false_type ) noexcept {
+    return internal::brick_walk2_n(__first1, n, __first2, f, is_vector);
 }
 
-template<class Iterator1, class Size, class Iterator2, class Function, class IsVector>
-Iterator2 pattern_walk2_n(Iterator1 first1, Size n, Iterator2 first2, Function f, IsVector is_vector, /*parallel=*/std::true_type ) {
-    return pattern_walk2(first1, first1 + n, first2, f, is_vector, std::true_type());
+template<class _RandomAccessIterator1, class _Size, class _RandomAccessIterator2, class Function, class IsVector>
+_RandomAccessIterator2 pattern_walk2_n(_RandomAccessIterator1 __first1, _Size n, _RandomAccessIterator2 __first2, Function f, IsVector is_vector, /*parallel=*/std::true_type ) {
+    return internal::pattern_walk2(__first1, __first1 + n, __first2, f, is_vector, std::true_type());
 }
 
-template<class Iterator1, class Iterator2, class Brick>
-Iterator2 pattern_walk2_brick( Iterator1 first1, Iterator1 last1, Iterator2 first2, Brick brick, /*parallel=*/std::false_type ) noexcept {
-    return brick(first1,last1,first2);
+template<class _ForwardIterator1, class _ForwardIterator2, class _Brick>
+_ForwardIterator2 pattern_walk2_brick( _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _Brick __brick, /*parallel=*/std::false_type ) noexcept {
+    return __brick(__first1,__last1,__first2);
 }
 
-template<class Iterator1, class Iterator2, class Brick>
-Iterator2 pattern_walk2_brick(Iterator1 first1, Iterator1 last1, Iterator2 first2, Brick brick, /*parallel=*/std::true_type ) {
+template<class _RandomAccessIterator1, class _RandomAccessIterator2, class _Brick>
+_RandomAccessIterator2 pattern_walk2_brick(_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2, _Brick __brick, /*parallel=*/std::true_type ) {
     return except_handler([=]() {
         par_backend::parallel_for(
-            first1, last1,
-            [first1,first2, brick](Iterator1 i, Iterator1 j) {
-                brick(i,j,first2+(i-first1));
+            __first1, __last1,
+            [__first1,__first2, __brick](_RandomAccessIterator1 __i, _RandomAccessIterator1 __j) {
+                __brick(__i, __j, __first2 + (__i - __first1));
             }
         );
-        return first2+(last1-first1);
+        return __first2 + (__last1 - __first1);
     });
 }
 
-template<class Iterator1, class Size, class Iterator2, class Brick>
-Iterator2 pattern_walk2_brick_n(Iterator1 first1, Size n, Iterator2 first2, Brick brick, /*parallel=*/std::true_type ) {
+template<class _RandomAccessIterator1, class _Size, class _RandomAccessIterator2, class _Brick>
+_RandomAccessIterator2 pattern_walk2_brick_n(_RandomAccessIterator1 __first1, _Size __n, _RandomAccessIterator2 __first2, _Brick __brick, /*parallel=*/std::true_type ) {
     return except_handler([=]() {
         par_backend::parallel_for(
-            first1, first1+n,
-            [first1,first2, brick](Iterator1 i, Iterator1 j) {
-                brick(i, j-i, first2+(i-first1));
+            __first1, __first1 + __n,
+            [__first1,__first2, __brick](_RandomAccessIterator1 __i, _RandomAccessIterator1 __j) {
+                __brick( __i, __j - __i, __first2 + (__i - __first1));
             }
         );
-        return first2 + n;
+        return __first2 + __n;
     });
 }
 
-template<class Iterator1, class Size, class Iterator2, class Brick>
-Iterator2 pattern_walk2_brick_n( Iterator1 first1, Size n, Iterator2 first2, Brick brick, /*parallel=*/std::false_type ) noexcept {
-    return brick(first1, n, first2);
+template<class _ForwardIterator1, class _Size, class _ForwardIterator2, class _Brick>
+_ForwardIterator2 pattern_walk2_brick_n( _ForwardIterator1 __first1, _Size __n, _ForwardIterator2 __first2, _Brick __brick, /*parallel=*/std::false_type ) noexcept {
+    return __brick(__first1, __n, __first2);
 }
 
 
@@ -321,56 +337,56 @@ Iterator2 pattern_walk2_brick_n( Iterator1 first1, Size n, Iterator2 first2, Bri
 //
 // it_walk2 evaluates f(it1, it2) for iterators (it1, it2) drawn from [first1,last1) and [first2,...)
 //------------------------------------------------------------------------
-template<class Iterator1, class Iterator2, class Function>
-Iterator2 brick_it_walk2( Iterator1 first1, Iterator1 last1, Iterator2 first2, Function f, /*vector=*/std::false_type ) noexcept {
-    for(; first1!=last1; ++first1, ++first2 )
-        f(first1, first2);
-    return first2;
+template<class _ForwardIterator1, class _ForwardIterator2, class _Function>
+_ForwardIterator2 brick_it_walk2( _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _Function __f, /*vector=*/std::false_type ) noexcept {
+    for(; __first1!=__last1; ++__first1, ++__first2 )
+        __f(__first1, __first2);
+    return __first2;
 }
 
-template<class Iterator1, class Iterator2, class Function>
-Iterator2 brick_it_walk2( Iterator1 first1, Iterator1 last1, Iterator2 first2, Function f, /*vector=*/std::true_type) noexcept {
-    return unseq_backend::simd_it_walk_2(first1, last1-first1, first2, f);
+template<class _ForwardIterator1, class _ForwardIterator2, class _Function>
+_ForwardIterator2 brick_it_walk2( _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _Function __f, /*vector=*/std::true_type) noexcept {
+    return unseq_backend::simd_it_walk_2(__first1, __last1-__first1, __first2, __f);
 }
 
-template<class Iterator1, class Size, class Iterator2, class Function>
-Iterator2 brick_it_walk2_n( Iterator1 first1, Size n, Iterator2 first2, Function f, /*vector=*/std::false_type ) noexcept {
-    for(; n > 0; --n, ++first1, ++first2 )
-        f(first1, first2);
-    return first2;
+template<class _ForwardIterator1, class _Size, class _ForwardIterator2, class _Function>
+_ForwardIterator2 brick_it_walk2_n( _ForwardIterator1 __first1, _Size n, _ForwardIterator2 __first2, _Function __f, /*vector=*/std::false_type ) noexcept {
+    for(; n > 0; --n, ++__first1, ++__first2 )
+        __f(__first1, __first2);
+    return __first2;
 }
 
-template<class Iterator1, class Size, class Iterator2, class Function>
-Iterator2 brick_it_walk2_n(Iterator1 first1, Size n, Iterator2 first2, Function f, /*vector=*/std::true_type) noexcept {
-    return unseq_backend::simd_it_walk_2(first1, n, first2, f);
+template<class _ForwardIterator1, class _Size, class _ForwardIterator2, class _Function>
+_ForwardIterator2 brick_it_walk2_n(_ForwardIterator1 __first1, _Size __n, _ForwardIterator2 __first2, _Function __f, /*vector=*/std::true_type) noexcept {
+    return unseq_backend::simd_it_walk_2(__first1, __n, __first2, __f);
 }
 
-template<class Iterator1, class Iterator2, class Function, class IsVector>
-Iterator2 pattern_it_walk2( Iterator1 first1, Iterator1 last1, Iterator2 first2, Function f, IsVector is_vector, /*parallel=*/std::false_type ) noexcept {
-    return brick_it_walk2(first1,last1,first2,f,is_vector);
+template<class _ForwardIterator1, class _ForwardIterator2, class _Function, class _IsVector>
+_ForwardIterator2 pattern_it_walk2( _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _Function __f, _IsVector __is_vector, /*parallel=*/std::false_type ) noexcept {
+    return internal::brick_it_walk2(__first1,__last1,__first2,__f,__is_vector);
 }
 
-template<class Iterator1, class Iterator2, class Function, class IsVector>
-Iterator2 pattern_it_walk2(Iterator1 first1, Iterator1 last1, Iterator2 first2, Function f, IsVector is_vector, /*parallel=*/std::true_type ) {
+template<class _RandomAccessIterator1, class _RandomAccessIterator2, class _Function, class _IsVector>
+_RandomAccessIterator2 pattern_it_walk2(_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2, _Function __f, _IsVector __is_vector, /*parallel=*/std::true_type ) {
     return except_handler([=]() {
         par_backend::parallel_for(
-            first1, last1,
-            [f,first1,first2,is_vector](Iterator1 i, Iterator1 j) {
-                brick_it_walk2(i,j,first2+(i-first1),f,is_vector);
+            __first1, __last1,
+            [__f,__first1,__first2,__is_vector](_RandomAccessIterator1 __i, _RandomAccessIterator1 __j) {
+                internal::brick_it_walk2( __i, __j, __first2 +(__i - __first1), __f, __is_vector);
             }
         );
-        return first2+(last1-first1);
+        return __first2 + (__last1 - __first1);
     });
 }
 
-template<class Iterator1, class Size, class Iterator2, class Function, class IsVector>
-Iterator2 pattern_it_walk2_n( Iterator1 first1, Size n, Iterator2 first2, Function f, IsVector is_vector, /*parallel=*/std::false_type ) noexcept {
-    return brick_it_walk2_n(first1, n, first2, f, is_vector);
+template<class _ForwardIterator1, class _Size, class _ForwardIterator2, class _Function, class _IsVector>
+_ForwardIterator2 pattern_it_walk2_n( _ForwardIterator1 __first1, _Size __n, _ForwardIterator2 __first2, _Function __f, _IsVector __is_vector, /*parallel=*/std::false_type ) noexcept {
+    return internal::brick_it_walk2_n(__first1, __n, __first2, __f, __is_vector);
 }
 
-template<class Iterator1, class Size, class Iterator2, class Function, class IsVector>
-Iterator2 pattern_it_walk2_n(Iterator1 first1, Size n, Iterator2 first2, Function f, IsVector is_vector, /*parallel=*/std::true_type ) {
-    return pattern_it_walk2(first1, first1 + n, first2, f, is_vector, std::true_type());
+template<class _ForwardIterator1, class _Size, class _ForwardIterator2, class _Function, class _IsVector>
+_ForwardIterator2 pattern_it_walk2_n(_ForwardIterator1 __first1, _Size __n, _ForwardIterator2 __first2, _Function __f, _IsVector __is_vector, /*parallel=*/std::true_type ) {
+    return internal::pattern_it_walk2(__first1, __first1 + __n, __first2, __f, __is_vector, std::true_type());
 }
 
 //------------------------------------------------------------------------
@@ -378,92 +394,94 @@ Iterator2 pattern_it_walk2_n(Iterator1 first1, Size n, Iterator2 first2, Functio
 //
 // walk3 evaluates f(x,y,z) for (x,y,z) drawn from [first1,last1), [first2,...), [first3,...)
 //------------------------------------------------------------------------
-template<class Iterator1, class Iterator2, class Iterator3, class Function>
-Iterator3 brick_walk3( Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator3 first3, Function f, /*vector=*/std::false_type ) noexcept {
-    for(; first1!=last1; ++first1, ++first2, ++first3 )
-        f(*first1, *first2, *first3);
-    return first3;
+template<class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator3, class _Function>
+_ForwardIterator3 brick_walk3( _ForwardIterator1 __first1, _ForwardIterator1 last1, _ForwardIterator2 __first2, _ForwardIterator3 __first3, _Function __f, /*vector=*/std::false_type ) noexcept {
+    for(; __first1!=last1; ++__first1, ++__first2, ++__first3 )
+        __f(*__first1, *__first2, *__first3);
+    return __first3;
 }
 
-template<class Iterator1, class Iterator2, class Iterator3, class Function>
-Iterator3 brick_walk3( Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator3 first3, Function f, /*vector=*/std::true_type) noexcept {
-    return unseq_backend::simd_walk_3(first1, last1-first1, first2, first3, f);
+template<class _RandomAccessIterator1, class _RandomAccessIterator2, class _RandomAccessIterator3, class _Function>
+_RandomAccessIterator3 brick_walk3( _RandomAccessIterator1 __first1, _RandomAccessIterator1 last1, _RandomAccessIterator2 __first2, _RandomAccessIterator3 __first3, _Function __f, /*vector=*/std::true_type) noexcept {
+    return unseq_backend::simd_walk_3(__first1, last1-__first1, __first2, __first3, __f);
 }
 
-
-template<class Iterator1, class Iterator2, class Iterator3, class Function, class IsVector>
-Iterator3 pattern_walk3( Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator3 first3, Function f, IsVector is_vector, /*parallel=*/std::false_type ) noexcept {
-    return brick_walk3(first1, last1, first2, first3, f, is_vector);
+template<class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator3, class _Function, class _IsVector>
+_ForwardIterator3 pattern_walk3( _ForwardIterator1 __first1, _ForwardIterator1 last1, _ForwardIterator2 __first2, _ForwardIterator3 __first3, _Function __f, _IsVector __is_vector, /*parallel=*/std::false_type ) noexcept {
+    return internal::brick_walk3(__first1, last1, __first2, __first3, __f, __is_vector);
 }
 
-template<class Iterator1, class Iterator2, class Iterator3, class Function, class IsVector>
-Iterator3 pattern_walk3(Iterator1 first1, Iterator1 last1, Iterator2 first2, Iterator3 first3, Function f, IsVector is_vector, /*parallel=*/std::true_type ) {
-    return except_handler([=]() {
+template<class _RandomAccessIterator1, class _RandomAccessIterator2, class _RandomAccessIterator3, class _Function, class _IsVector>
+_RandomAccessIterator3 pattern_walk3(_RandomAccessIterator1 __first1, _RandomAccessIterator1 last1, _RandomAccessIterator2 __first2, _RandomAccessIterator3 __first3, _Function __f, _IsVector __is_vector, /*parallel=*/std::true_type ) {
+    return internal::except_handler([=]() {
         par_backend::parallel_for(
-            first1, last1,
-            [f, first1, first2, first3, is_vector](Iterator1 i, Iterator1 j) {
-            brick_walk3(i, j, first2+(i-first1), first3+(i-first1), f, is_vector);
+            __first1, last1,
+            [__f, __first1, __first2, __first3, __is_vector](_RandomAccessIterator1 __i, _RandomAccessIterator1 __j) {
+            internal::brick_walk3(__i, __j, __first2 + (__i - __first1), __first3 + (__i - __first1), __f, __is_vector);
         });
-        return first3+(last1-first1);
+        return __first3+(last1-__first1);
     });
 }
-
 
 //------------------------------------------------------------------------
 // equal
 //------------------------------------------------------------------------
 
-template<class InputIterator1, class InputIterator2, class BinaryPredicate>
-bool brick_equal(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, BinaryPredicate p, /* IsVector = */ std::false_type) noexcept {
-    return std::equal(first1, last1, first2, p);
+template<class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+bool brick_equal(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _BinaryPredicate __p, /* IsVector = */ std::false_type) noexcept {
+    return std::equal(__first1, __last1, __first2, __p);
 }
 
-template<class InputIterator1, class InputIterator2, class BinaryPredicate>
-bool brick_equal(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, BinaryPredicate p, /* is_vector = */ std::true_type) noexcept {
-    return unseq_backend::simd_first(first1, last1 - first1, first2, not_pred<BinaryPredicate>(p)).first == last1;
+template<class _RandomAccessIterator1, class _RandomAccessIterator2, class _BinaryPredicate>
+bool brick_equal(_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2, _BinaryPredicate __p, /* is_vector = */ std::true_type) noexcept {
+    return unseq_backend::simd_first(__first1, __last1 - __first1, __first2, not_pred<_BinaryPredicate>(__p)).first == __last1;
 }
 
-template<class InputIterator1, class InputIterator2, class BinaryPredicate, class IsVector>
-bool pattern_equal(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, BinaryPredicate p, IsVector is_vector, /* is_parallel = */ std::false_type) noexcept {
-    return brick_equal(first1, last1, first2, p, is_vector);
+template<class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate, class _IsVector>
+bool pattern_equal(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _BinaryPredicate __p, _IsVector __is_vector, /* is_parallel = */ std::false_type) noexcept {
+    return internal::brick_equal(__first1, __last1, __first2, __p, __is_vector);
 }
 
-template<class InputIterator1, class InputIterator2, class BinaryPredicate, class IsVector>
-bool pattern_equal(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, BinaryPredicate p, IsVector vec, /*is_parallel=*/std::true_type) {
-    return except_handler([=]() {
-        return !internal::parallel_or(first1, last1,
-            [first1, first2, p, vec](InputIterator1 i, InputIterator1 j) {return !brick_equal(i, j,
-                first2 + (i - first1), p, vec); });
+template<class _RandomAccessIterator1, class _RandomAccessIterator2, class _BinaryPredicate, class _IsVector>
+bool pattern_equal(_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2, _BinaryPredicate __p, _IsVector __is_vector, /*is_parallel=*/std::true_type) {
+    return internal::except_handler([=]() {
+        return !internal::parallel_or(__first1, __last1,
+            [__first1, __first2, __p, __is_vector](_RandomAccessIterator1 __i, _RandomAccessIterator1 __j)
+                                      {
+                                        return !brick_equal(__i, __j, __first2 + (__i - __first1), __p, __is_vector);
+                                      });
     });
 }
 
 //------------------------------------------------------------------------
 // find_if
 //------------------------------------------------------------------------
-template<class ForwardIterator, class Predicate>
-ForwardIterator brick_find_if(ForwardIterator first, ForwardIterator last, Predicate pred, /*is_vector=*/std::false_type) noexcept {
-    return std::find_if(first, last, pred);
+template<class _ForwardIterator, class _Predicate>
+_ForwardIterator brick_find_if(_ForwardIterator __first, _ForwardIterator __last, _Predicate __pred, /*is_vector=*/std::false_type) noexcept {
+    return std::find_if(__first, __last, __pred);
 }
 
-template<class ForwardIterator, class Predicate>
-ForwardIterator brick_find_if(ForwardIterator first, ForwardIterator last, Predicate pred, /*is_vector=*/std::true_type) noexcept {
-    typedef typename std::iterator_traits<ForwardIterator>::difference_type size_type;
-    return unseq_backend::simd_first(first, size_type(0), last - first,
-        [&pred](ForwardIterator it, size_type i) {return pred(it[i]); });
+template<class _RandomAccessIterator, class _Predicate>
+_RandomAccessIterator brick_find_if(_RandomAccessIterator __first, _RandomAccessIterator __last, _Predicate __pred, /*is_vector=*/std::true_type) noexcept {
+    typedef typename std::iterator_traits<_RandomAccessIterator>::difference_type _size_type;
+    return unseq_backend::simd_first(__first, _size_type(0), __last - __first,
+        [&__pred](_RandomAccessIterator __it, _size_type __i) {return __pred(__it[__i]); });
 }
 
-template<class ForwardIterator, class Predicate, class IsVector>
-ForwardIterator pattern_find_if(ForwardIterator first, ForwardIterator last, Predicate pred, IsVector is_vector, /*is_parallel=*/std::false_type ) noexcept {
-    return brick_find_if(first,last,pred,is_vector);
+template<class _ForwardIterator, class _Predicate, class _IsVector>
+_ForwardIterator pattern_find_if(_ForwardIterator __first, _ForwardIterator __last, _Predicate __pred, _IsVector __is_vector,
+                                 /*is_parallel=*/std::false_type ) noexcept {
+    return internal::brick_find_if( __first, __last, __pred, __is_vector);
 }
 
-template<class ForwardIterator, class Predicate, class IsVector>
-ForwardIterator pattern_find_if(ForwardIterator first, ForwardIterator last, Predicate pred, IsVector is_vector, /*is_parallel=*/std::true_type) {
-    return except_handler([=]() {
-        return internal::parallel_find(first, last, [pred, is_vector](ForwardIterator i, ForwardIterator j) {
-            return brick_find_if(i, j, pred, is_vector);
+template<class _ForwardIterator, class _Predicate, class _IsVector>
+_ForwardIterator pattern_find_if(_ForwardIterator __first, _ForwardIterator __last, _Predicate __pred, _IsVector __is_vector,
+                                 /*is_parallel=*/std::true_type) {
+    return internal::except_handler([=]() {
+        return internal::parallel_find(__first, __last, [__pred, __is_vector](_ForwardIterator __i, _ForwardIterator __j) {
+            return internal::brick_find_if(__i, __j, __pred, __is_vector);
         },
-        std::less<typename std::iterator_traits<ForwardIterator>::difference_type>(), /*is_first=*/true);
+        std::less<typename std::iterator_traits<_ForwardIterator>::difference_type>(), /*is___first=*/true);
     });
 }
 
@@ -474,106 +492,108 @@ ForwardIterator pattern_find_if(ForwardIterator first, ForwardIterator last, Pre
 // find the first occurrence of the subsequence [s_first, s_last)
 //   or the  last occurrence of the subsequence in the range [first, last)
 // b_first determines what occurrence we want to find (first or last)
-template<class ForwardIterator1, class ForwardIterator2, class BinaryPredicate, class IsVector>
-ForwardIterator1 find_subrange(ForwardIterator1 first, ForwardIterator1 last,
-    ForwardIterator1 global_last, ForwardIterator2 s_first, ForwardIterator2 s_last,
-    BinaryPredicate pred, bool b_first, IsVector is_vector) noexcept {
-    typedef typename std::iterator_traits<ForwardIterator2>::value_type value_type;
-    auto  n2 = s_last - s_first;
-    if (n2 < 1) {
-        return b_first ? first : last;
+template<class _RandomAccessIterator1, class _RandomAccessIterator2, class _BinaryPredicate, class _IsVector>
+_RandomAccessIterator1 find_subrange(_RandomAccessIterator1 __first, _RandomAccessIterator1 __last,
+    _RandomAccessIterator1 __global_last, _RandomAccessIterator2 __s_first, _RandomAccessIterator2 __s_last,
+    _BinaryPredicate __pred, bool __b_first, _IsVector __is_vector) noexcept {
+    typedef typename std::iterator_traits<_RandomAccessIterator2>::value_type _value_type;
+    auto  __n2 = __s_last - __s_first;
+    if (__n2 < 1) {
+        return __b_first ? __first : __last;
     }
 
-    auto  n1 = global_last - first;
-    if (n1 < n2) {
-        return last;
+    auto  __n1 = __global_last - __first;
+    if (__n1 < __n2) {
+        return __last;
     }
 
-    auto cur = last;
-    while (first != last && (global_last - first >= n2)) {
+    auto __cur = __last;
+    while (__first != __last && (__global_last - __first >= __n2)) {
         // find position of *s_first in [first, last) (it can be start of subsequence)
-        first = brick_find_if(first, last,
-            equal_value_by_pred<value_type, BinaryPredicate>(*s_first, pred), is_vector);
+        __first = internal::brick_find_if(__first, __last,
+                                          internal::equal_value_by_pred<_value_type, _BinaryPredicate>(*__s_first, __pred),
+                                          __is_vector);
 
         // if position that was found previously is the start of subsequence
         // then we can exit the loop (b_first == true) or keep the position
         // (b_first == false)
-        if (first != last && (global_last - first >= n2) &&
-            brick_equal(s_first + 1, s_last, first + 1, pred, is_vector)) {
-            if (b_first) {
-                return first;
+        if (__first != __last && (__global_last - __first >= __n2) &&
+            internal::brick_equal(__s_first + 1, __s_last, __first + 1, __pred, __is_vector)) {
+            if (__b_first) {
+                return __first;
             }
             else {
-                cur = first;
+                __cur = __first;
             }
         }
-        else if (first == last) {
+        else if (__first == __last) {
             break;
         }
         else {}
 
         // in case of b_first == false we try to find new start position
         // for the next subsequence
-        ++first;
+        ++__first;
     }
-    return cur;
+    return __cur;
 }
 
-template<class ForwardIterator, class Size, class T, class BinaryPredicate, class IsVector>
-ForwardIterator find_subrange(ForwardIterator first, ForwardIterator last,
-    ForwardIterator global_last, Size count, const T& value,
-    BinaryPredicate pred, IsVector is_vector) noexcept {
-    if (global_last - first < count || count < 1) {
-        return last; // According to the standard last shall be returned when count < 1
+template<class _RandomAccessIterator, class _Size, class _Tp, class _BinaryPredicate, class _IsVector>
+_RandomAccessIterator find_subrange(_RandomAccessIterator __first, _RandomAccessIterator __last,
+    _RandomAccessIterator __global_last, _Size __count, const _Tp& __value,
+    _BinaryPredicate __pred, _IsVector __is_vector) noexcept {
+    if (__global_last - __first < __count || __count < 1) {
+        return __last; // According to the standard last shall be returned when count < 1
     }
 
-    auto n = global_last - first;
-    auto unary_pred = equal_value_by_pred<T, BinaryPredicate>(value, pred);
-    while (first != last && (global_last - first >= count)) {
-        first = brick_find_if(first, last, unary_pred, is_vector);
+    auto __n = __global_last - __first;
+    auto __unary_pred = internal::equal_value_by_pred<_Tp, _BinaryPredicate>(__value, __pred);
+    while (__first != __last && (__global_last - __first >= __count)) {
+        __first = brick_find_if(__first, __last, __unary_pred, __is_vector);
 
         // check that all of elements in [first+1, first+count) equal to value
-        if (first != last && (global_last - first >= count) &&
-            !brick_any_of(first + 1, first + count, not_pred<decltype(unary_pred)>(unary_pred), is_vector)) {
-                return first;
+        if (__first != __last && (__global_last - __first >= __count) &&
+            !internal::brick_any_of(__first + 1, __first + __count,
+                                    internal::not_pred<decltype(__unary_pred)>(__unary_pred), __is_vector)) {
+                return __first;
         }
-        else if (first == last) {
+        else if (__first == __last) {
             break;
         }
         else {
-            ++first;
+            ++__first;
         }
     }
-    return last;
+    return __last;
 }
 
-template<class ForwardIterator1, class ForwardIterator2, class BinaryPredicate>
-ForwardIterator1 brick_find_end(ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 s_first, ForwardIterator2 s_last, BinaryPredicate pred, /*is_vector=*/std::false_type) noexcept {
-    return std::find_end(first, last, s_first, s_last, pred);
+template<class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+_ForwardIterator1 brick_find_end(_ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last, _BinaryPredicate __pred, /*__is_vector=*/std::false_type) noexcept {
+    return std::find_end(__first, __last, __s_first, __s_last, __pred);
 }
 
-template<class ForwardIterator1, class ForwardIterator2, class BinaryPredicate>
-ForwardIterator1 brick_find_end(ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 s_first, ForwardIterator2 s_last, BinaryPredicate pred, /*is_vector=*/std::true_type) noexcept {
-    return find_subrange(first, last, last, s_first, s_last, pred, false, std::true_type());
+template<class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+_ForwardIterator1 brick_find_end(_ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last, _BinaryPredicate __pred, /*__is_vector=*/std::true_type) noexcept {
+    return internal::find_subrange(__first, __last, __last, __s_first, __s_last, __pred, false, std::true_type());
 }
 
-template<class ForwardIterator1, class ForwardIterator2, class BinaryPredicate, class IsVector>
-ForwardIterator1 pattern_find_end(ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 s_first, ForwardIterator2 s_last, BinaryPredicate pred, IsVector is_vector, /*is_parallel=*/std::false_type) noexcept {
-    return brick_find_end(first, last, s_first, s_last, pred, is_vector);
+template<class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate, class _IsVector>
+_ForwardIterator1 pattern_find_end(_ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last, _BinaryPredicate __pred, _IsVector __is_vector, /*is_parallel=*/std::false_type) noexcept {
+    return internal::brick_find_end(__first, __last, __s_first, __s_last, __pred, __is_vector);
 }
 
-template<class ForwardIterator1, class ForwardIterator2, class BinaryPredicate, class IsVector>
-ForwardIterator1 pattern_find_end(ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 s_first, ForwardIterator2 s_last, BinaryPredicate pred, IsVector is_vector, /*is_parallel=*/std::true_type) noexcept {
-    if (last - first == s_last - s_first) {
-        const bool res = pattern_equal(first, last, s_first, pred, is_vector, std::true_type());
-        return res ? first : last;
+template<class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate, class _IsVector>
+_ForwardIterator1 pattern_find_end(_ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last, _BinaryPredicate __pred, _IsVector __is_vector, /*is_parallel=*/std::true_type) noexcept {
+    if (__last - __first == __s_last - __s_first) {
+        const bool __res = internal::pattern_equal(__first, __last, __s_first, __pred, __is_vector, std::true_type());
+        return __res ? __first : __last;
     }
     else {
         return except_handler([=]() {
-            return internal::parallel_find(first, last, [first, last, s_first, s_last, pred, is_vector](ForwardIterator1 i, ForwardIterator1 j) {
-                return find_subrange(i, j, last, s_first, s_last, pred, false, is_vector);
+            return internal::parallel_find(__first, __last, [__first, __last, __s_first, __s_last, __pred, __is_vector](_ForwardIterator1 __i, _ForwardIterator1 __j) {
+                return internal::find_subrange(__i, __j, __last, __s_first, __s_last, __pred, false, __is_vector);
             },
-            std::greater<typename std::iterator_traits<ForwardIterator1>::difference_type>(), /*is_first=*/false);
+            std::greater<typename std::iterator_traits<_ForwardIterator1>::difference_type>(), /*is_first=*/false);
         });
     }
 }
@@ -581,61 +601,61 @@ ForwardIterator1 pattern_find_end(ForwardIterator1 first, ForwardIterator1 last,
 //------------------------------------------------------------------------
 // find_first_of
 //------------------------------------------------------------------------
-template<class ForwardIterator1, class ForwardIterator2, class BinaryPredicate>
-ForwardIterator1 brick_find_first_of(ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 s_first, ForwardIterator2 s_last, BinaryPredicate pred, /*is_vector=*/std::false_type) noexcept {
-    return std::find_first_of(first, last, s_first, s_last, pred);
+template<class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+_ForwardIterator1 brick_find_first_of(_ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last, _BinaryPredicate __pred, /*__is_vector=*/std::false_type) noexcept {
+    return std::find_first_of(__first, __last, __s_first, __s_last, __pred);
 }
 
-template<class ForwardIterator1, class ForwardIterator2, class BinaryPredicate>
-ForwardIterator1 brick_find_first_of(ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 s_first, ForwardIterator2 s_last, BinaryPredicate pred, /*is_vector=*/std::true_type) noexcept {
-    return unseq_backend::simd_find_first_of(first, last, s_first, s_last, pred);
+template<class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+_ForwardIterator1 brick_find_first_of(_ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last, _BinaryPredicate __pred, /*__is_vector=*/std::true_type) noexcept {
+    return unseq_backend::simd_find_first_of(__first, __last, __s_first, __s_last, __pred);
 }
 
-template<class ForwardIterator1, class ForwardIterator2, class BinaryPredicate, class IsVector>
-ForwardIterator1 pattern_find_first_of(ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 s_first, ForwardIterator2 s_last, BinaryPredicate pred, IsVector is_vector, /*is_parallel=*/std::false_type) noexcept {
-    return brick_find_first_of(first, last, s_first, s_last, pred, is_vector);
+template<class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate, class _IsVector>
+_ForwardIterator1 pattern_find_first_of(_ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last, _BinaryPredicate __pred, _IsVector __is_vector, /*is_parallel=*/std::false_type) noexcept {
+    return internal::brick_find_first_of(__first, __last, __s_first, __s_last, __pred, __is_vector);
 }
 
-template<class ForwardIterator1, class ForwardIterator2, class BinaryPredicate, class IsVector>
-ForwardIterator1 pattern_find_first_of(ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 s_first, ForwardIterator2 s_last, BinaryPredicate pred, IsVector is_vector, /*is_parallel=*/std::true_type) noexcept {
+template<class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate, class _IsVector>
+_ForwardIterator1 pattern_find_first_of(_ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last, _BinaryPredicate __pred, _IsVector __is_vector, /*is_parallel=*/std::true_type) noexcept {
     return except_handler([=]() {
-        return internal::parallel_find(first, last, [s_first, s_last, pred, is_vector](ForwardIterator1 i, ForwardIterator1 j) {
-            return brick_find_first_of(i, j, s_first, s_last, pred, is_vector);
+        return internal::parallel_find(__first, __last, [__s_first, __s_last, __pred, __is_vector](_ForwardIterator1 __i, _ForwardIterator1 __j) {
+            return internal::brick_find_first_of(__i, __j, __s_first, __s_last, __pred, __is_vector);
         },
-        std::less<typename std::iterator_traits<ForwardIterator1>::difference_type>(), /*is_first=*/true);
+        std::less<typename std::iterator_traits<_ForwardIterator1>::difference_type>(), /*is_first=*/true);
     });
 }
 
 //------------------------------------------------------------------------
 // search
 //------------------------------------------------------------------------
-template<class ForwardIterator1, class ForwardIterator2, class BinaryPredicate>
-ForwardIterator1 brick_search(ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 s_first, ForwardIterator2 s_last, BinaryPredicate pred, /*vector=*/std::false_type) noexcept {
-    return std::search(first, last, s_first, s_last, pred);
+template<class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+_ForwardIterator1 brick_search(_ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last, _BinaryPredicate __pred, /*vector=*/std::false_type) noexcept {
+    return std::search(__first, __last, __s_first, __s_last, __pred);
 }
 
-template<class ForwardIterator1, class ForwardIterator2, class BinaryPredicate>
-ForwardIterator1 brick_search(ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 s_first, ForwardIterator2 s_last, BinaryPredicate pred, /*vector=*/std::true_type) noexcept {
-    return find_subrange(first, last, last, s_first, s_last, pred, true, std::true_type());
+template<class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+_ForwardIterator1 brick_search(_ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last, _BinaryPredicate __pred, /*vector=*/std::true_type) noexcept {
+    return internal::find_subrange(__first, __last, __last, __s_first, __s_last, __pred, true, std::true_type());
 }
 
-template<class ForwardIterator1, class ForwardIterator2, class BinaryPredicate, class IsVector>
-ForwardIterator1 pattern_search(ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 s_first, ForwardIterator2 s_last, BinaryPredicate pred, IsVector is_vector, /*is_parallel=*/std::false_type) noexcept {
-    return brick_search(first, last, s_first, s_last, pred, is_vector);
+template<class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate, class _IsVector>
+_ForwardIterator1 pattern_search(_ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last, _BinaryPredicate __pred, _IsVector __is_vector, /*is_parallel=*/std::false_type) noexcept {
+    return internal::brick_search(__first, __last, __s_first, __s_last, __pred, __is_vector);
 }
 
-template<class ForwardIterator1, class ForwardIterator2, class BinaryPredicate, class IsVector>
-ForwardIterator1 pattern_search(ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 s_first, ForwardIterator2 s_last, BinaryPredicate pred, IsVector is_vector, /*is_parallel=*/std::true_type) noexcept {
-    if (last - first == s_last - s_first) {
-        const bool res = pattern_equal(first, last, s_first, pred, is_vector, std::true_type());
-        return res ? first : last;
+template<class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate, class _IsVector>
+_ForwardIterator1 pattern_search(_ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last, _BinaryPredicate __pred, _IsVector __is_vector, /*is_parallel=*/std::true_type) noexcept {
+    if (__last - __first == __s_last - __s_first) {
+        const bool __res = internal::pattern_equal(__first, __last, __s_first, __pred, __is_vector, std::true_type());
+        return __res ? __first : __last;
     }
     else {
         return except_handler([=]() {
-            return internal::parallel_find(first, last, [last, s_first, s_last, pred, is_vector](ForwardIterator1 i, ForwardIterator1 j) {
-                return find_subrange(i, j, last, s_first, s_last, pred, true, is_vector);
+            return internal::parallel_find(__first, __last, [__last, __s_first, __s_last, __pred, __is_vector](_ForwardIterator1 __i, _ForwardIterator1 __j) {
+                return internal::find_subrange(__i, __j, __last, __s_first, __s_last, __pred, true, __is_vector);
             },
-            std::less<typename std::iterator_traits<ForwardIterator1>::difference_type>(), /*is_first=*/true);
+            std::less<typename std::iterator_traits<_ForwardIterator1>::difference_type>(), /*is_first=*/true);
         });
     }
 }
@@ -643,618 +663,611 @@ ForwardIterator1 pattern_search(ForwardIterator1 first, ForwardIterator1 last, F
 //------------------------------------------------------------------------
 // search_n
 //------------------------------------------------------------------------
-template<class ForwardIterator, class Size, class T, class BinaryPredicate>
-ForwardIterator brick_search_n(ForwardIterator first, ForwardIterator last, Size count, const T& value, BinaryPredicate pred, /*vector=*/std::false_type) noexcept {
-    return std::search_n(first, last, count, value, pred);
+template<class _ForwardIterator, class _Size, class _Tp, class _BinaryPredicate>
+_ForwardIterator brick_search_n(_ForwardIterator __first, _ForwardIterator __last, _Size __count, const _Tp& __value, _BinaryPredicate __pred, /*vector=*/std::false_type) noexcept {
+    return std::search_n(__first, __last, __count, __value, __pred);
 }
 
-template<class ForwardIterator, class Size, class T, class BinaryPredicate>
-ForwardIterator brick_search_n(ForwardIterator first, ForwardIterator last, Size count, const T& value, BinaryPredicate pred, /*vector=*/std::true_type) noexcept {
-    return find_subrange(first, last, last, count, value, pred, std::true_type());
+template<class _ForwardIterator, class _Size, class _Tp, class _BinaryPredicate>
+_ForwardIterator brick_search_n(_ForwardIterator __first, _ForwardIterator __last, _Size __count, const _Tp& __value, _BinaryPredicate __pred, /*vector=*/std::true_type) noexcept {
+    return internal::find_subrange(__first, __last, __last, __count, __value, __pred, std::true_type());
 }
 
-template<class ForwardIterator, class Size, class T, class BinaryPredicate, class IsVector>
-ForwardIterator pattern_search_n(ForwardIterator first, ForwardIterator last, Size count, const T& value, BinaryPredicate pred, IsVector is_vector, /*is_parallel=*/std::false_type) noexcept {
-    return brick_search_n(first, last, count, value, pred, is_vector);
+template<class _ForwardIterator, class _Size, class _Tp, class _BinaryPredicate, class IsVector>
+_ForwardIterator pattern_search_n(_ForwardIterator __first, _ForwardIterator __last, _Size __count, const _Tp& __value, _BinaryPredicate __pred, IsVector __is_vector, /*is_parallel=*/std::false_type) noexcept {
+    return internal::brick_search_n(__first, __last, __count, __value, __pred, __is_vector);
 }
 
-template<class ForwardIterator, class Size, class T, class BinaryPredicate, class IsVector>
-ForwardIterator pattern_search_n(ForwardIterator first, ForwardIterator last, Size count, const T& value, BinaryPredicate pred, IsVector is_vector, /*is_parallel=*/std::true_type) noexcept {
-    if (last - first == count) {
-        const bool result = !pattern_any_of(first, last,
-            [&value, &pred](const T& val) {return !pred(val, value); },
-            is_vector, /*is_parallel*/ std::true_type());
-        return result ? first : last;
+template<class _RandomAccessIterator, class _Size, class _Tp, class _BinaryPredicate, class IsVector>
+_RandomAccessIterator pattern_search_n(_RandomAccessIterator __first, _RandomAccessIterator __last, _Size __count, const _Tp& __value, _BinaryPredicate __pred, IsVector __is_vector, /*is_parallel=*/std::true_type) noexcept {
+    if (__last - __first == __count) {
+        const bool __result = !internal::pattern_any_of(__first, __last,
+            [&__value, &__pred](const _Tp& __val) {return !__pred(__val, __value); },
+            __is_vector, /*is_parallel*/ std::true_type());
+        return __result ? __first : __last;
     }
     else {
-        return except_handler([first, last, count, &value, pred, is_vector]() {
-            return internal::parallel_find(first, last, [last, count, &value, pred, is_vector](ForwardIterator i, ForwardIterator j) {
-                return find_subrange(i, j, last, count, value, pred, is_vector);
+        return except_handler([__first, __last, __count, &__value, __pred, __is_vector]() {
+            return internal::parallel_find(__first, __last, [__last, __count, &__value, __pred, __is_vector](_RandomAccessIterator __i, _RandomAccessIterator __j) {
+                return internal::find_subrange(__i, __j, __last, __count, __value, __pred, __is_vector);
             },
-            std::less<typename std::iterator_traits<ForwardIterator>::difference_type>(), /*is_first=*/true);
+            std::less<typename std::iterator_traits<_RandomAccessIterator>::difference_type>(), /*is_first=*/true);
         });
     }
 }
-
 
 //------------------------------------------------------------------------
 // copy_n
 //------------------------------------------------------------------------
 
-template<class InputIterator, class Size, class OutputIterator>
-OutputIterator brick_copy_n(InputIterator first, Size n, OutputIterator result, /*vector=*/std::false_type) noexcept {
-    return std::copy_n(first, n, result);
+template<class _ForwardIterator, class _Size, class _OutputIterator>
+_OutputIterator brick_copy_n(_ForwardIterator __first, _Size __n, _OutputIterator __result, /*vector=*/std::false_type) noexcept {
+    return std::copy_n(__first, __n, __result);
 }
 
-template<class InputIterator, class Size, class OutputIterator>
-OutputIterator brick_copy_n(InputIterator first, Size n, OutputIterator result, /*vector=*/std::true_type) noexcept {
-    return unseq_backend::simd_copy_move(first, n, result,
-        [](InputIterator first, OutputIterator result) {
-            *result = *first;
+template<class _ForwardIterator, class _Size, class _OutputIterator>
+_OutputIterator brick_copy_n(_ForwardIterator __first, _Size __n, _OutputIterator __result, /*vector=*/std::true_type) noexcept {
+    return unseq_backend::simd_copy_move(__first, __n, __result,
+        [](_ForwardIterator __first, _OutputIterator __result) {
+            *__result = *__first;
     });
 }
 
 //------------------------------------------------------------------------
 // copy
 //------------------------------------------------------------------------
-template<class InputIterator, class OutputIterator>
-OutputIterator brick_copy(InputIterator first, InputIterator last, OutputIterator result, /*vector=*/std::false_type) noexcept {
-    return std::copy(first, last, result);
+template<class _ForwardIterator, class _OutputIterator>
+_OutputIterator brick_copy(_ForwardIterator __first, _ForwardIterator __last, _OutputIterator __result, /*vector=*/std::false_type) noexcept {
+    return std::copy(__first, __last, __result);
 }
 
-template<class InputIterator, class OutputIterator>
-OutputIterator brick_copy(InputIterator first, InputIterator last, OutputIterator result, /*vector=*/std::true_type) noexcept {
-    return unseq_backend::simd_copy_move(first, last - first, result,
-        [](InputIterator first, OutputIterator result) {
-            *result = *first;
+template<class _RandomAccessIterator, class _OutputIterator>
+_OutputIterator brick_copy(_RandomAccessIterator __first, _RandomAccessIterator __last, _OutputIterator __result, /*vector=*/std::true_type) noexcept {
+    return unseq_backend::simd_copy_move(__first, __last - __first, __result,
+        [](_RandomAccessIterator __first, _OutputIterator __result) {
+            *__result = *__first;
     });
 }
 
 //------------------------------------------------------------------------
 // move
 //------------------------------------------------------------------------
-template<class InputIterator, class OutputIterator>
-OutputIterator brick_move(InputIterator first, InputIterator last, OutputIterator result, /*vector=*/std::false_type) noexcept {
-    return std::move(first, last, result);
+template<class _ForwardIterator, class _OutputIterator>
+_OutputIterator brick_move(_ForwardIterator __first, _ForwardIterator __last, _OutputIterator __result, /*vector=*/std::false_type) noexcept {
+    return std::move(__first, __last, __result);
 }
 
-template<class InputIterator, class OutputIterator>
-OutputIterator brick_move(InputIterator first, InputIterator last, OutputIterator result, /*vector=*/std::true_type) noexcept {
-    return unseq_backend::simd_copy_move(first, last - first, result,
-        [](InputIterator first, OutputIterator result) {
-        *result = std::move(*first);
+template<class _RandomAccessIterator, class _OutputIterator>
+_OutputIterator brick_move(_RandomAccessIterator __first, _RandomAccessIterator __last, _OutputIterator __result, /*vector=*/std::true_type) noexcept {
+    return unseq_backend::simd_copy_move(__first, __last - __first, __result,
+        [](_RandomAccessIterator __first, _OutputIterator __result) {
+        *__result = std::move(*__first);
     });
 }
 
 //------------------------------------------------------------------------
 // copy_if
 //------------------------------------------------------------------------
-template<class InputIterator, class OutputIterator, class UnaryPredicate>
-OutputIterator brick_copy_if(InputIterator first, InputIterator last, OutputIterator result, UnaryPredicate pred, /*vector=*/std::false_type) noexcept {
-    return std::copy_if(first, last, result, pred);
+template<class _ForwardIterator, class OutputIterator, class _UnaryPredicate>
+OutputIterator brick_copy_if(_ForwardIterator __first, _ForwardIterator __last, OutputIterator __result, _UnaryPredicate __pred, /*vector=*/std::false_type) noexcept {
+    return std::copy_if(__first, __last, __result, __pred);
 }
 
-template<class InputIterator, class OutputIterator, class UnaryPredicate>
-OutputIterator brick_copy_if(InputIterator first, InputIterator last, OutputIterator result, UnaryPredicate pred, /*vector=*/std::true_type) noexcept {
+template<class _ForwardIterator, class OutputIterator, class _UnaryPredicate>
+OutputIterator brick_copy_if(_ForwardIterator __first, _ForwardIterator __last, OutputIterator __result, _UnaryPredicate __pred, /*vector=*/std::true_type) noexcept {
 #if (__PSTL_MONOTONIC_PRESENT)
-    return unseq_backend::simd_copy_if(first, last-first, result, pred);
+    return unseq_backend::simd_copy_if(__first, __last - __first, __result, __pred);
 #else
-    return std::copy_if(first, last, result, pred);
+    return std::copy_if(__first, __last, __result, __pred);
 #endif
 }
 
 // TODO: Try to use transform_reduce for combining brick_copy_if_phase1 on IsVector.
-template<class DifferenceType, class InputIterator, class UnaryPredicate>
-std::pair<DifferenceType, DifferenceType> brick_calc_mask_1(
-    InputIterator first, InputIterator last, bool* __restrict mask, UnaryPredicate pred, /*vector=*/std::false_type) noexcept {
-    auto count_true  = DifferenceType(0);
-    auto count_false = DifferenceType(0);
-    auto size = std::distance(first, last);
+template<class _DifferenceType, class _ForwardIterator, class _UnaryPredicate>
+std::pair<_DifferenceType, _DifferenceType> brick_calc_mask_1(
+    _ForwardIterator __first, _ForwardIterator __last, bool* __restrict __mask, _UnaryPredicate __pred, /*vector=*/std::false_type) noexcept {
+    auto __count_true  = _DifferenceType(0);
+    auto __count_false = _DifferenceType(0);
+    auto __size = std::distance(__first, __last);
 
-    for (; first != last; ++first, ++mask) {
-        *mask = pred(*first);
-        if (*mask) {
-            ++count_true;
+    for (; __first != __last; ++__first, ++__mask) {
+        *__mask = __pred(*__first);
+        if (*__mask) {
+            ++__count_true;
         }
     }
-    return std::make_pair(count_true, size - count_true);
+    return std::make_pair(__count_true, __size - __count_true);
 }
 
-template<class DifferenceType, class InputIterator, class UnaryPredicate>
-std::pair<DifferenceType, DifferenceType> brick_calc_mask_1(
-    InputIterator first, InputIterator last, bool* __restrict mask, UnaryPredicate pred, /*vector=*/std::true_type) noexcept {
-    auto result = unseq_backend::simd_calc_mask_1(first, last - first, mask, pred);
-    return std::make_pair(result, (last - first) - result);
+template<class _DifferenceType, class _RandomAccessIterator, class _UnaryPredicate>
+std::pair<_DifferenceType, _DifferenceType> brick_calc_mask_1(
+    _RandomAccessIterator __first, _RandomAccessIterator __last, bool* __restrict __mask, _UnaryPredicate __pred, /*vector=*/std::true_type) noexcept {
+    auto __result = unseq_backend::simd_calc_mask_1(__first, __last - __first, __mask, __pred);
+    return std::make_pair(__result, (__last - __first) - __result);
 }
 
-template<class InputIterator, class OutputIterator>
-void brick_copy_by_mask(InputIterator first, InputIterator last, OutputIterator result, bool* mask, /*vector=*/std::false_type) noexcept {
-    for (; first != last; ++first, ++mask) {
-        if (*mask) {
-            *result = *first;
-            ++result;
+template<class _ForwardIterator, class _OutputIterator>
+void brick_copy_by_mask(_ForwardIterator __first, _ForwardIterator __last, _OutputIterator __result, bool* __mask, /*vector=*/std::false_type) noexcept {
+    for (; __first != __last; ++__first, ++__mask) {
+        if (*__mask) {
+            *__result = *__first;
+            ++__result;
         }
     }
 }
 
-template<class InputIterator, class OutputIterator>
-void brick_copy_by_mask(InputIterator first, InputIterator last, OutputIterator result, bool* __restrict mask, /*vector=*/std::true_type) noexcept {
+template<class _ForwardIterator, class _OutputIterator>
+void brick_copy_by_mask(_ForwardIterator __first, _ForwardIterator __last, _OutputIterator __result, bool* __restrict __mask, /*vector=*/std::true_type) noexcept {
 #if (__PSTL_MONOTONIC_PRESENT)
-    unseq_backend::simd_copy_by_mask(first, last - first, result, mask);
+    unseq_backend::simd_copy_by_mask(__first, __last - __first, __result, __mask);
 #else
-    brick_copy_by_mask(first, last, result, mask, std::false_type());
+    internal::brick_copy_by_mask(__first, __last, __result, __mask, std::false_type());
 #endif
 
 }
 
-template<class InputIterator, class OutputIterator1, class OutputIterator2>
-void brick_partition_by_mask(InputIterator first, InputIterator last, OutputIterator1 out_true,
-    OutputIterator2 out_false, bool* mask, /*vector=*/std::false_type) noexcept {
-    for (; first != last; ++first, ++mask) {
-        if (*mask) {
-            *out_true = *first;
-            ++out_true;
+template<class _ForwardIterator, class _OutputIterator1, class _OutputIterator2>
+void brick_partition_by_mask(_ForwardIterator __first, _ForwardIterator __last, _OutputIterator1 __out_true,
+    _OutputIterator2 __out_false, bool* __mask, /*vector=*/std::false_type) noexcept {
+    for (; __first != __last; ++__first, ++__mask) {
+        if (*__mask) {
+            *__out_true = *__first;
+            ++__out_true;
         }
         else {
-            *out_false = *first;
-            ++out_false;
+            *__out_false = *__first;
+            ++__out_false;
         }
     }
 }
 
-template<class InputIterator, class OutputIterator1, class OutputIterator2>
-void brick_partition_by_mask(InputIterator first, InputIterator last, OutputIterator1 out_true,
-    OutputIterator2 out_false, bool* mask, /*vector=*/std::true_type) noexcept {
+template<class _RandomAccessIterator, class _OutputIterator1, class _OutputIterator2>
+void brick_partition_by_mask(_RandomAccessIterator __first, _RandomAccessIterator __last, _OutputIterator1 __out_true,
+    _OutputIterator2 __out_false, bool* __mask, /*vector=*/std::true_type) noexcept {
 #if (__PSTL_MONOTONIC_PRESENT)
-    unseq_backend::simd_partition_by_mask(first, last - first, out_true, out_false, mask);
+    unseq_backend::simd_partition_by_mask(__first, __last - __first, __out_true, __out_false, __mask);
 #else
-    brick_partition_by_mask(first, last, out_true, out_false, mask, std::false_type());
+    internal::brick_partition_by_mask(__first, __last, __out_true, __out_false, __mask, std::false_type());
 #endif
-
 }
 
-template<class InputIterator, class OutputIterator, class UnaryPredicate, class IsVector>
-OutputIterator pattern_copy_if(InputIterator first, InputIterator last, OutputIterator result, UnaryPredicate pred, IsVector is_vector, /*parallel=*/std::false_type) noexcept {
-    return brick_copy_if(first, last, result, pred, is_vector);
+template<class _ForwardIterator, class _OutputIterator, class _UnaryPredicate, class _IsVector>
+_OutputIterator pattern_copy_if(_ForwardIterator __first, _ForwardIterator __last, _OutputIterator __result, _UnaryPredicate __pred, _IsVector __is_vector, /*parallel=*/std::false_type) noexcept {
+    return internal::brick_copy_if(__first, __last, __result, __pred, __is_vector);
 }
 
-template<class InputIterator, class OutputIterator, class UnaryPredicate, class IsVector>
-OutputIterator pattern_copy_if(InputIterator first, InputIterator last, OutputIterator result, UnaryPredicate pred, IsVector is_vector, /*parallel=*/std::true_type) {
-    typedef typename std::iterator_traits<InputIterator>::difference_type difference_type;
-    const difference_type n = last-first;
-    if( difference_type(1) < n ) {
-        par_backend::buffer<bool> mask_buf(n);
-        if( mask_buf ) {
-            return except_handler([n, first, last, result, is_vector, pred, &mask_buf]() {
-                bool* mask = mask_buf.get();
-                difference_type m;
-                par_backend::parallel_strict_scan( n, difference_type(0),
-                    [=](difference_type i, difference_type len) {                               // Reduce
-                        return brick_calc_mask_1<difference_type>(first+i, first+(i+len),
-                                                                 mask + i,
-                                                                 pred,
-                                                                 is_vector).first;
+template<class _RandomAccessIterator, class _OutputIterator, class _UnaryPredicate, class _IsVector>
+_OutputIterator pattern_copy_if(_RandomAccessIterator __first, _RandomAccessIterator __last, _OutputIterator __result, _UnaryPredicate __pred, _IsVector __is_vector, /*parallel=*/std::true_type) {
+    typedef typename std::iterator_traits<_RandomAccessIterator>::difference_type _difference_type;
+    const _difference_type __n = __last-__first;
+    if( _difference_type(1) < __n ) {
+        par_backend::buffer<bool> __mask_buf(__n);
+        if( __mask_buf ) {
+            return internal::except_handler([__n, __first, __last, __result, __is_vector, __pred, &__mask_buf]() {
+                bool* __mask = __mask_buf.get();
+                _difference_type __m;
+                par_backend::parallel_strict_scan( __n, _difference_type(0),
+                    [=](_difference_type __i, _difference_type __len) {                               // Reduce
+                        return internal::brick_calc_mask_1<_difference_type>(__first + __i, __first + (__i + __len),
+                                                                             __mask + __i,
+                                                                             __pred,
+                                                                             __is_vector).first;
                     },
-                    std::plus<difference_type>(),                                               // Combine
-                    [=](difference_type i, difference_type len, difference_type initial) {      // Scan
-                        brick_copy_by_mask(first+i, first+(i+len),
-                                                            result+initial,
-                                                            mask + i,
-                                                            is_vector);
+                    std::plus<_difference_type>(),                                               // Combine
+                    [=](_difference_type __i, _difference_type __len, _difference_type __initial) {      // Scan
+                        internal::brick_copy_by_mask(__first + __i, __first + (__i + __len),
+                                                     __result + __initial,
+                                                     __mask + __i,
+                                                     __is_vector);
                     },
-                    [&m](difference_type total) {m=total;});
-                return result + m;
+                    [&__m](_difference_type __total) {__m = __total;});
+                return __result + __m;
             });
         }
     }
-    // Out of memory or trivial sequence - use serial algorithm
-    return brick_copy_if(first, last, result, pred, is_vector);
+    // _Out of memory or trivial sequence - use serial algorithm
+    return brick_copy_if(__first, __last, __result, __pred, __is_vector);
 }
 
 //------------------------------------------------------------------------
 // unique
 //------------------------------------------------------------------------
 
-template<class ForwardIterator, class BinaryPredicate>
-ForwardIterator brick_unique(ForwardIterator first, ForwardIterator last, BinaryPredicate pred, /*is_vector=*/std::false_type) noexcept {
-    return std::unique(first, last, pred);
+template<class _ForwardIterator, class _BinaryPredicate>
+_ForwardIterator brick_unique(_ForwardIterator __first, _ForwardIterator __last, _BinaryPredicate __pred, /*is_vector=*/std::false_type) noexcept {
+    return std::unique(__first, __last, __pred);
 }
 
-template<class ForwardIterator, class BinaryPredicate>
-ForwardIterator brick_unique(ForwardIterator first, ForwardIterator last, BinaryPredicate pred, /*is_vector=*/std::true_type) noexcept {
+template<class _ForwardIterator, class _BinaryPredicate>
+_ForwardIterator brick_unique(_ForwardIterator __first, _ForwardIterator __last, _BinaryPredicate __pred, /*is_vector=*/std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
-    return std::unique(first, last, pred);
+    return std::unique(__first, __last, __pred);
 }
 
-template<class ForwardIterator, class BinaryPredicate, class IsVector>
-ForwardIterator pattern_unique(ForwardIterator first, ForwardIterator last, BinaryPredicate pred, IsVector is_vector, /*is_parallel=*/std::false_type) noexcept {
-    return brick_unique(first, last, pred, is_vector);
+template<class _ForwardIterator, class _BinaryPredicate, class _IsVector>
+_ForwardIterator pattern_unique(_ForwardIterator __first, _ForwardIterator __last, _BinaryPredicate __pred, _IsVector __is_vector, /*is_parallel=*/std::false_type) noexcept {
+    return internal::brick_unique(__first, __last, __pred, __is_vector);
 }
 
-template<class ForwardIterator, class BinaryPredicate, class IsVector>
-ForwardIterator pattern_unique(ForwardIterator first, ForwardIterator last, BinaryPredicate pred, IsVector is_vector, /*is_parallel=*/std::true_type) noexcept {
+template<class _ForwardIterator, class _BinaryPredicate, class _IsVector>
+_ForwardIterator pattern_unique(_ForwardIterator __first, _ForwardIterator __last, _BinaryPredicate __pred, _IsVector __is_vector, /*is_parallel=*/std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Parallel algorithm unimplemented, redirected to serial");
-    return brick_unique(first, last, pred, is_vector);
+    return internal::brick_unique(__first, __last, __pred, __is_vector);
 }
 
 //------------------------------------------------------------------------
 // unique_copy
 //------------------------------------------------------------------------
 
-template<class InputIterator, class OutputIterator, class BinaryPredicate>
-OutputIterator brick_unique_copy(InputIterator first, InputIterator last, OutputIterator result, BinaryPredicate pred, /*vector=*/std::false_type) noexcept {
-    return std::unique_copy(first, last, result, pred);
+template<class _ForwardIterator, class OutputIterator, class _BinaryPredicate>
+OutputIterator brick_unique_copy(_ForwardIterator __first, _ForwardIterator __last, OutputIterator __result, _BinaryPredicate __pred, /*vector=*/std::false_type) noexcept {
+    return std::unique_copy(__first, __last, __result, __pred);
 }
 
-template<class InputIterator, class OutputIterator, class BinaryPredicate>
-OutputIterator brick_unique_copy(InputIterator first, InputIterator last, OutputIterator result, BinaryPredicate pred, /*vector=*/std::true_type) noexcept {
+template<class _RandomAccessIterator, class OutputIterator, class _BinaryPredicate>
+OutputIterator brick_unique_copy(_RandomAccessIterator __first, _RandomAccessIterator __last, OutputIterator __result, _BinaryPredicate __pred, /*vector=*/std::true_type) noexcept {
 #if (__PSTL_MONOTONIC_PRESENT)
-    return unseq_backend::simd_unique_copy(first, last-first, result, pred);
+    return unseq_backend::simd_unique_copy(__first, __last - __first, __result, __pred);
 #else
-    return std::unique_copy(first, last, result, pred);
+    return std::unique_copy(__first, __last, __result, __pred);
 #endif
 }
 
-template<class InputIterator, class OutputIterator, class BinaryPredicate, class IsVector>
-OutputIterator pattern_unique_copy(InputIterator first, InputIterator last, OutputIterator result, BinaryPredicate pred, IsVector is_vector, /*parallel=*/std::false_type) noexcept {
-    return brick_unique_copy(first, last, result, pred, is_vector);
+template<class _ForwardIterator, class OutputIterator, class _BinaryPredicate, class _IsVector>
+OutputIterator pattern_unique_copy(_ForwardIterator __first, _ForwardIterator __last, OutputIterator __result, _BinaryPredicate __pred, _IsVector __is_vector, /*parallel=*/std::false_type) noexcept {
+    return internal::brick_unique_copy(__first, __last, __result, __pred, __is_vector);
 }
 
-template<class DifferenceType, class InputIterator, class BinaryPredicate>
-DifferenceType brick_calc_mask_2(InputIterator first, InputIterator last, bool* __restrict mask, BinaryPredicate pred, /*vector=*/std::false_type) noexcept {
-    DifferenceType count = 0;
-    for (; first != last; ++first, ++mask) {
-        *mask = !pred(*first, *(first-1));
-        count += *mask;
+template<class _DifferenceType, class _RandomAccessIterator, class _BinaryPredicate>
+_DifferenceType brick_calc_mask_2(_RandomAccessIterator __first, _RandomAccessIterator __last, bool* __restrict __mask, _BinaryPredicate __pred, /*vector=*/std::false_type) noexcept {
+    _DifferenceType count = 0;
+    for (; __first != __last; ++__first, ++__mask) {
+        *__mask = !__pred(*__first, *(__first - 1));
+        count += *__mask;
     }
     return count;
 }
 
-template<class DifferenceType, class InputIterator, class BinaryPredicate>
-DifferenceType brick_calc_mask_2(InputIterator first, InputIterator last, bool* __restrict mask, BinaryPredicate pred, /*vector=*/std::true_type) noexcept {
-    return unseq_backend::simd_calc_mask_2(first, last-first, mask, pred);
+template<class _DifferenceType, class _RandomAccessIterator, class _BinaryPredicate>
+_DifferenceType brick_calc_mask_2(_RandomAccessIterator __first, _RandomAccessIterator __last, bool* __restrict __mask, _BinaryPredicate __pred, /*vector=*/std::true_type) noexcept {
+    return unseq_backend::simd_calc_mask_2(__first, __last - __first, __mask, __pred);
 }
 
-template<class InputIterator, class OutputIterator, class BinaryPredicate, class IsVector>
-OutputIterator pattern_unique_copy(InputIterator first, InputIterator last, OutputIterator result, BinaryPredicate pred, IsVector is_vector, /*parallel=*/std::true_type) {
-    typedef typename std::iterator_traits<InputIterator>::difference_type difference_type;
-    const difference_type n = last-first;
-    if( difference_type(2)<n ) {
-        par_backend::buffer<bool> mask_buf(n);
-        if( difference_type(2)<n && mask_buf ) {
-            return except_handler([n, first, result, pred, is_vector, &mask_buf]() {
-                bool* mask = mask_buf.get();
-                difference_type m;
-                par_backend::parallel_strict_scan( n, difference_type(0),
-                    [=](difference_type i, difference_type len) -> difference_type {          // Reduce
-                        difference_type extra = 0;
-                        if( i==0 ) {
+template<class _RandomAccessIterator, class _OutputIterator, class _BinaryPredicate, class _IsVector>
+_OutputIterator pattern_unique_copy(_RandomAccessIterator __first, _RandomAccessIterator __last, _OutputIterator __result, _BinaryPredicate __pred, _IsVector __is_vector, /*parallel=*/std::true_type) {
+    typedef typename std::iterator_traits<_RandomAccessIterator>::difference_type _difference_type;
+    const _difference_type __n = __last - __first;
+    if( _difference_type(2) < __n ) {
+        par_backend::buffer<bool> __mask_buf(__n);
+        if( _difference_type(2) < __n && __mask_buf ) {
+          return internal::except_handler([__n, __first, __result, __pred, __is_vector, &__mask_buf]() {
+                bool* __mask = __mask_buf.get();
+                _difference_type __m;
+                par_backend::parallel_strict_scan( __n, _difference_type(0),
+                    [=](_difference_type __i, _difference_type __len) -> _difference_type {          // Reduce
+                        _difference_type __extra = 0;
+                        if( __i == 0 ) {
                             // Special boundary case
-                            mask[i] = true;
-                            if( --len==0 ) return 1;
-                            ++i;
-                            ++extra;
+                            __mask[__i] = true;
+                            if( --__len == 0 ) return 1;
+                            ++__i;
+                            ++__extra;
                         }
-                        return brick_calc_mask_2<difference_type>(
-                            first+i, first+(i+len),
-                            mask + i,
-                            pred,
-                            is_vector) + extra;
+                        return brick_calc_mask_2<_difference_type>(__first + __i, __first + (__i + __len),
+                                                                   __mask + __i,
+                                                                   __pred,
+                                                                   __is_vector) + __extra;
                     },
-                    std::plus<difference_type>(),                                               // Combine
-                    [=](difference_type i, difference_type len, difference_type initial) {      // Scan
+                    std::plus<_difference_type>(),                                               // Combine
+                    [=](_difference_type __i, _difference_type __len, _difference_type __initial) {      // Scan
                         // Phase 2 is same as for pattern_copy_if
-                        brick_copy_by_mask(
-                            first+i, first+(i+len),
-                            result+initial,
-                            mask + i,
-                            is_vector);
+                        internal::brick_copy_by_mask(__first + __i, __first + (__i + __len),
+                                                     __result + __initial,
+                                                     __mask + __i,
+                                                     __is_vector);
                     },
-                    [&m](difference_type total) {m=total;});
-                return result + m;
+                    [&__m](_difference_type __total) {__m = __total;});
+                return __result + __m;
             });
         }
     }
     // Out of memory or trivial sequence - use serial algorithm
-    return brick_unique_copy(first, last, result, pred, is_vector);
+    return brick_unique_copy(__first, __last, __result, __pred, __is_vector);
 }
 
 //------------------------------------------------------------------------
 // swap_ranges
 //------------------------------------------------------------------------
 
-template<class ForwardIterator1, class ForwardIterator2>
-ForwardIterator2 brick_swap_ranges(ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, /*is_vector=*/std::false_type) noexcept {
-    return std::swap_ranges(first1, last1, first2);
+template<class _ForwardIterator1, class _ForwardIterator2>
+_ForwardIterator2 brick_swap_ranges(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, /*__is_vector=*/std::false_type) noexcept {
+    return std::swap_ranges(__first1, __last1, __first2);
 }
 
-template<class ForwardIterator1, class ForwardIterator2>
-ForwardIterator2 brick_swap_ranges(ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, /*is_vector=*/std::true_type) noexcept {
+template<class _ForwardIterator1, class _ForwardIterator2>
+_ForwardIterator2 brick_swap_ranges(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, /*__is_vector=*/std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
-    return std::swap_ranges(first1, last1, first2);
+    return std::swap_ranges(__first1, __last1, __first2);
 }
 
-template<class ForwardIterator1, class ForwardIterator2, class IsVector>
-ForwardIterator2 pattern_swap_ranges(ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, IsVector is_vector, /*is_parallel=*/std::false_type) noexcept {
-    return brick_swap_ranges(first1, last1, first2, is_vector);
+template<class _ForwardIterator1, class _ForwardIterator2, class _IsVector>
+_ForwardIterator2 pattern_swap_ranges(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _IsVector __is_vector, /*is_parallel=*/std::false_type) noexcept {
+    return internal::brick_swap_ranges(__first1, __last1, __first2, __is_vector);
 }
 
-template<class ForwardIterator1, class ForwardIterator2, class IsVector>
-ForwardIterator2 pattern_swap_ranges(ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, IsVector is_vector, /*is_parallel=*/std::true_type) noexcept {
+template<class _ForwardIterator1, class _ForwardIterator2, class _IsVector>
+_ForwardIterator2 pattern_swap_ranges(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _IsVector __is_vector, /*is_parallel=*/std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Parallel algorithm unimplemented, redirected to serial");
-    return brick_swap_ranges(first1, last1, first2, is_vector);
+    return internal::brick_swap_ranges(__first1, __last1, __first2, __is_vector);
 }
 
 //------------------------------------------------------------------------
 // reverse
 //------------------------------------------------------------------------
 
-template<class BidirectionalIterator>
-void brick_reverse(BidirectionalIterator first, BidirectionalIterator last,/*is_vector=*/std::false_type) noexcept {
-    std::reverse(first, last);
+template<class _BidirectionalIterator>
+void brick_reverse(_BidirectionalIterator __first, _BidirectionalIterator __last,/*__is_vector=*/std::false_type) noexcept {
+    std::reverse(__first, __last);
 }
 
-template<class BidirectionalIterator>
-void brick_reverse(BidirectionalIterator first, BidirectionalIterator last,/*is_vector=*/std::true_type) noexcept {
+template<class _BidirectionalIterator>
+void brick_reverse(_BidirectionalIterator __first, _BidirectionalIterator __last,/*__is_vector=*/std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
-    brick_reverse(first, last, std::false_type());
+    internal::brick_reverse(__first, __last, std::false_type());
 }
 
-template<class BidirectionalIterator, class IsVector>
-void pattern_reverse(BidirectionalIterator first, BidirectionalIterator last, IsVector is_vector, /*is_parallel=*/std::false_type) noexcept {
-    brick_reverse(first, last, is_vector);
+template<class _BidirectionalIterator, class _IsVector>
+void pattern_reverse(_BidirectionalIterator __first, _BidirectionalIterator __last, _IsVector __is_vector, /*is_parallel=*/std::false_type) noexcept {
+    internal::brick_reverse(__first, __last, __is_vector);
 }
 
-template<class BidirectionalIterator, class IsVector>
-void pattern_reverse(BidirectionalIterator first, BidirectionalIterator last, IsVector is_vector, /*is_parallel=*/std::true_type) noexcept {
+template<class _BidirectionalIterator, class _IsVector>
+void pattern_reverse(_BidirectionalIterator __first, _BidirectionalIterator __last, _IsVector __is_vector, /*is_parallel=*/std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Parallel algorithm unimplemented, redirected to serial");
-    brick_reverse(first, last, is_vector);
+    internal::brick_reverse(__first, __last, __is_vector);
 }
 
 //------------------------------------------------------------------------
 // reverse_copy
 //------------------------------------------------------------------------
 
-template<class BidirectionalIterator, class OutputIterator>
-OutputIterator brick_reverse_copy(BidirectionalIterator first, BidirectionalIterator last, OutputIterator d_first, /*is_vector=*/std::false_type) noexcept {
-    return std::reverse_copy(first, last, d_first);
+template<class _BidirectionalIterator, class _OutputIterator>
+_OutputIterator brick_reverse_copy(_BidirectionalIterator __first, _BidirectionalIterator __last, _OutputIterator __d_first, /*is_vector=*/std::false_type) noexcept {
+    return std::reverse_copy(__first, __last, __d_first);
 }
 
-template<class BidirectionalIterator, class OutputIterator>
-OutputIterator brick_reverse_copy(BidirectionalIterator first, BidirectionalIterator last, OutputIterator d_first, /*is_vector=*/std::true_type) noexcept {
+template<class _BidirectionalIterator, class _OutputIterator>
+_OutputIterator brick_reverse_copy(_BidirectionalIterator __first, _BidirectionalIterator __last, _OutputIterator __d_first, /*is_vector=*/std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
-    return brick_reverse_copy(first, last, d_first, std::false_type());
+    return internal::brick_reverse_copy(__first, __last, __d_first, std::false_type());
 }
 
-template<class BidirectionalIterator, class OutputIterator, class IsVector>
-OutputIterator pattern_reverse_copy(BidirectionalIterator first, BidirectionalIterator last, OutputIterator d_first, IsVector is_vector, /*is_parallel=*/std::false_type) noexcept {
-    return brick_reverse_copy(first, last, d_first, is_vector);
+template<class _BidirectionalIterator, class _OutputIterator, class _IsVector>
+_OutputIterator pattern_reverse_copy(_BidirectionalIterator __first, _BidirectionalIterator __last, _OutputIterator __d_first, _IsVector __is_vector, /*is_parallel=*/std::false_type) noexcept {
+    return internal::brick_reverse_copy(__first, __last, __d_first, __is_vector);
 }
 
-template<class BidirectionalIterator, class OutputIterator, class IsVector>
-OutputIterator pattern_reverse_copy(BidirectionalIterator first, BidirectionalIterator last, OutputIterator d_first, IsVector is_vector, /*is_parallel=*/std::true_type) noexcept {
+template<class _BidirectionalIterator, class _OutputIterator, class _IsVector>
+_OutputIterator pattern_reverse_copy(_BidirectionalIterator __first, _BidirectionalIterator __last, _OutputIterator __d_first, _IsVector __is_vector, /*is_parallel=*/std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Parallel algorithm unimplemented, redirected to serial");
-    return brick_reverse_copy(first, last, d_first, is_vector);
+    return internal::brick_reverse_copy(__first, __last, __d_first, __is_vector);
 }
 
 //------------------------------------------------------------------------
 // rotate
 //------------------------------------------------------------------------
-template<class ForwardIterator>
-ForwardIterator brick_rotate(ForwardIterator first, ForwardIterator middle, ForwardIterator last, /*is_vector=*/std::false_type) noexcept {
+template<class _ForwardIterator>
+_ForwardIterator brick_rotate(_ForwardIterator __first, _ForwardIterator __middle, _ForwardIterator __last, /*is_vector=*/std::false_type) noexcept {
 #if __PSTL_CPP11_STD_ROTATE_BROKEN
-    std::rotate(first, middle, last);
-    return std::next(first, std::distance(middle, last));
+    std::rotate(__first, __middle, __last);
+    return std::next(__first, std::distance(__middle, __last));
 #else
-    return std::rotate(first, middle, last);
+    return std::rotate(__first, __middle, __last);
 #endif
 }
 
-template<class ForwardIterator>
-ForwardIterator brick_rotate(ForwardIterator first, ForwardIterator middle, ForwardIterator last, /*is_vector=*/std::true_type) noexcept {
+template<class _ForwardIterator>
+_ForwardIterator brick_rotate(_ForwardIterator __first, _ForwardIterator __middle, _ForwardIterator __last, /*is_vector=*/std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
-    return brick_rotate(first, middle, last, std::false_type());
+    return internal::brick_rotate(__first, __middle, __last, std::false_type());
 }
 
-template<class ForwardIterator, class IsVector>
-ForwardIterator pattern_rotate(ForwardIterator first, ForwardIterator middle, ForwardIterator last, IsVector is_vector, /*is_parallel=*/std::false_type) noexcept {
-    return brick_rotate(first, middle, last, is_vector);
+template<class _ForwardIterator, class _IsVector>
+_ForwardIterator pattern_rotate(_ForwardIterator __first, _ForwardIterator __middle, _ForwardIterator __last, _IsVector __is_vector, /*is_parallel=*/std::false_type) noexcept {
+    return internal::brick_rotate(__first, __middle, __last, __is_vector);
 }
 
-template<class ForwardIterator, class IsVector>
-ForwardIterator pattern_rotate(ForwardIterator first, ForwardIterator middle, ForwardIterator last, IsVector is_vector, /*is_parallel=*/std::true_type) noexcept {
+template<class _ForwardIterator, class _IsVector>
+_ForwardIterator pattern_rotate(_ForwardIterator __first, _ForwardIterator __middle, _ForwardIterator __last, _IsVector __is_vector, /*is_parallel=*/std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Parallel algorithm unimplemented, redirected to serial");
-    return brick_rotate(first, middle, last, is_vector);
+    return internal::brick_rotate(__first, __middle, __last, __is_vector);
 }
 
 //------------------------------------------------------------------------
 // rotate_copy
 //------------------------------------------------------------------------
 
-template<class ForwardIterator, class OutputIterator>
-OutputIterator brick_rotate_copy(ForwardIterator first, ForwardIterator middle, ForwardIterator last, OutputIterator result, /*is_vector=*/std::false_type) noexcept {
-    return std::rotate_copy(first, middle, last, result);
+template<class _ForwardIterator, class _OutputIterator>
+_OutputIterator brick_rotate_copy(_ForwardIterator __first, _ForwardIterator __middle, _ForwardIterator __last, _OutputIterator __result, /*__is_vector=*/std::false_type) noexcept {
+    return std::rotate_copy(__first, __middle, __last, __result);
 }
 
-template<class ForwardIterator, class OutputIterator>
-OutputIterator brick_rotate_copy(ForwardIterator first, ForwardIterator middle, ForwardIterator last, OutputIterator result, /*is_vector=*/std::true_type) noexcept {
+template<class _ForwardIterator, class _OutputIterator>
+_OutputIterator brick_rotate_copy(_ForwardIterator __first, _ForwardIterator __middle, _ForwardIterator __last, _OutputIterator __result, /*__is_vector=*/std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
-    return std::rotate_copy(first, middle, last, result);
+    return std::rotate_copy(__first, __middle, __last, __result);
 }
 
-template<class ForwardIterator, class OutputIterator, class IsVector>
-OutputIterator pattern_rotate_copy(ForwardIterator first, ForwardIterator middle, ForwardIterator last, OutputIterator result, IsVector is_vector, /*is_parallel=*/std::false_type) noexcept {
-    return brick_rotate_copy(first, middle, last, result, is_vector);
+template<class _ForwardIterator, class _OutputIterator, class _IsVector>
+_OutputIterator pattern_rotate_copy(_ForwardIterator __first, _ForwardIterator __middle, _ForwardIterator __last, _OutputIterator __result, _IsVector __is_vector, /*is_parallel=*/std::false_type) noexcept {
+    return internal::brick_rotate_copy(__first, __middle, __last, __result, __is_vector);
 }
 
-template<class ForwardIterator, class OutputIterator, class IsVector>
-OutputIterator pattern_rotate_copy(ForwardIterator first, ForwardIterator middle, ForwardIterator last, OutputIterator result, IsVector is_vector, /*is_parallel=*/std::true_type) noexcept {
+template<class _ForwardIterator, class _OutputIterator, class _IsVector>
+_OutputIterator pattern_rotate_copy(_ForwardIterator __first, _ForwardIterator __middle, _ForwardIterator __last, _OutputIterator __result, _IsVector __is_vector, /*is_parallel=*/std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Parallel algorithm unimplemented, redirected to serial");
-    return brick_rotate_copy(first, middle, last, result, is_vector);
+    return internal::brick_rotate_copy(__first, __middle, __last, __result, __is_vector);
 }
 
 //------------------------------------------------------------------------
 // is_partitioned
 //------------------------------------------------------------------------
 
-template<class InputIterator, class UnaryPredicate>
-bool brick_is_partitioned(InputIterator first, InputIterator last, UnaryPredicate pred, /*is_vector=*/std::false_type) noexcept
+template<class _ForwardIterator, class _UnaryPredicate>
+bool brick_is_partitioned(_ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred, /*is_vector=*/std::false_type) noexcept
 {
-    return std::is_partitioned(first, last, pred);
+    return std::is_partitioned(__first, __last, __pred);
 }
 
-template<class InputIterator, class UnaryPredicate>
-bool brick_is_partitioned(InputIterator first, InputIterator last, UnaryPredicate pred, /*is_vector=*/std::true_type) noexcept {
+template<class _ForwardIterator, class _UnaryPredicate>
+bool brick_is_partitioned(_ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred, /*is_vector=*/std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
-    return brick_is_partitioned(first, last, pred, std::false_type());
+    return internal::brick_is_partitioned(__first, __last, __pred, std::false_type());
 }
 
-template<class InputIterator, class UnaryPredicate, class IsVector>
-bool pattern_is_partitioned(InputIterator first, InputIterator last, UnaryPredicate pred, IsVector is_vector, /*is_parallel=*/std::false_type) noexcept {
-    return brick_is_partitioned(first, last, pred, is_vector);
+template<class _ForwardIterator, class _UnaryPredicate, class _IsVector>
+bool pattern_is_partitioned(_ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred, _IsVector __is_vector, /*is_parallel=*/std::false_type) noexcept {
+    return internal::brick_is_partitioned(__first, __last, __pred, __is_vector);
 }
 
 
-template<class InputIterator, class UnaryPredicate, class IsVector>
-bool pattern_is_partitioned(InputIterator first, InputIterator last, UnaryPredicate pred, IsVector is_vector, /*is_parallel=*/std::true_type) noexcept {
+template<class _ForwardIterator, class _UnaryPredicate, class _IsVector>
+bool pattern_is_partitioned(_ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred, _IsVector __is_vector, /*is_parallel=*/std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Parallel algorithm unimplemented, redirected to serial");
-    return brick_is_partitioned(first, last, pred, is_vector);
+    return internal::brick_is_partitioned(__first, __last, __pred, __is_vector);
 }
 
 //------------------------------------------------------------------------
 // partition
 //------------------------------------------------------------------------
 
-template<class ForwardIterator, class UnaryPredicate>
-ForwardIterator brick_partition(ForwardIterator first, ForwardIterator last, UnaryPredicate pred, /*is_vector=*/std::false_type) noexcept {
-    return std::partition(first, last, pred);
+template<class _ForwardIterator, class _UnaryPredicate>
+_ForwardIterator brick_partition(_ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred, /*is_vector=*/std::false_type) noexcept {
+    return std::partition(__first, __last, __pred);
 }
 
-template<class ForwardIterator, class UnaryPredicate>
-ForwardIterator brick_partition(ForwardIterator first, ForwardIterator last, UnaryPredicate pred, /*is_vector=*/std::true_type) noexcept {
+template<class _ForwardIterator, class _UnaryPredicate>
+_ForwardIterator brick_partition(_ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred, /*is_vector=*/std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
-    return std::partition(first, last, pred);
+    return std::partition(__first, __last, __pred);
 }
 
-template<class ForwardIterator, class UnaryPredicate, class IsVector>
-ForwardIterator pattern_partition(ForwardIterator first, ForwardIterator last, UnaryPredicate pred, IsVector is_vector, /*is_parallel=*/std::false_type) noexcept {
-    return brick_partition(first, last, pred, is_vector);
+template<class _ForwardIterator, class _UnaryPredicate, class _IsVector>
+_ForwardIterator pattern_partition(_ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred, _IsVector __is_vector, /*is_parallel=*/std::false_type) noexcept {
+    return internal::brick_partition(__first, __last, __pred, __is_vector);
 }
 
-template<class ForwardIterator, class UnaryPredicate, class IsVector>
-ForwardIterator pattern_partition(ForwardIterator first, ForwardIterator last, UnaryPredicate pred, IsVector is_vector, /*is_parallel=*/std::true_type) noexcept {
+template<class _ForwardIterator, class _UnaryPredicate, class _IsVector>
+_ForwardIterator pattern_partition(_ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred, _IsVector __is_vector, /*is_parallel=*/std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Parallel algorithm unimplemented, redirected to serial");
-    return brick_partition(first, last, pred, is_vector);
+    return internal::brick_partition(__first, __last, __pred, __is_vector);
 }
 
 //------------------------------------------------------------------------
 // stable_partition
 //------------------------------------------------------------------------
 
-template<class BidirectionalIterator, class UnaryPredicate>
-BidirectionalIterator brick_stable_partition(BidirectionalIterator first, BidirectionalIterator last, UnaryPredicate pred, /*is_vector=*/std::false_type) noexcept {
-    return std::stable_partition(first, last, pred);
+template<class _BidirectionalIterator, class _UnaryPredicate>
+_BidirectionalIterator brick_stable_partition(_BidirectionalIterator __first, _BidirectionalIterator __last, _UnaryPredicate __pred, /*__is_vector=*/std::false_type) noexcept {
+    return std::stable_partition(__first, __last, __pred);
 }
 
-template<class BidirectionalIterator, class UnaryPredicate>
-BidirectionalIterator brick_stable_partition(BidirectionalIterator first, BidirectionalIterator last, UnaryPredicate pred, /*is_vector=*/std::true_type) noexcept {
+template<class _BidirectionalIterator, class _UnaryPredicate>
+_BidirectionalIterator brick_stable_partition(_BidirectionalIterator __first, _BidirectionalIterator __last, _UnaryPredicate __pred, /*__is_vector=*/std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
-    return std::stable_partition(first, last, pred);
+    return std::stable_partition(__first, __last, __pred);
 }
 
-template<class BidirectionalIterator, class UnaryPredicate, class IsVector>
-BidirectionalIterator pattern_stable_partition(BidirectionalIterator first, BidirectionalIterator last, UnaryPredicate pred, IsVector is_vector, /*is_parallelization=*/std::false_type) noexcept {
-    return brick_stable_partition(first, last, pred, is_vector);
+template<class _BidirectionalIterator, class _UnaryPredicate, class _IsVector>
+_BidirectionalIterator pattern_stable_partition(_BidirectionalIterator __first, _BidirectionalIterator __last, _UnaryPredicate __pred, _IsVector __is_vector, /*is_parallelization=*/std::false_type) noexcept {
+    return internal::brick_stable_partition(__first, __last, __pred, __is_vector);
 }
 
-template<class BidirectionalIterator, class UnaryPredicate, class IsVector>
-BidirectionalIterator pattern_stable_partition(BidirectionalIterator first, BidirectionalIterator last, UnaryPredicate pred, IsVector is_vector, /*is_parallelization=*/std::true_type) noexcept {
+template<class _BidirectionalIterator, class _UnaryPredicate, class _IsVector>
+_BidirectionalIterator pattern_stable_partition(_BidirectionalIterator __first, _BidirectionalIterator __last, _UnaryPredicate __pred, _IsVector __is_vector, /*is_parallelization=*/std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Parallel algorithm unimplemented, redirected to serial");
-    return brick_stable_partition(first, last, pred, is_vector);
+    return internal::brick_stable_partition(__first, __last, __pred, __is_vector);
 }
 
 //------------------------------------------------------------------------
 // partition_copy
 //------------------------------------------------------------------------
 
-template<class InputIterator, class OutputIterator1, class OutputIterator2, class UnaryPredicate>
-std::pair<OutputIterator1, OutputIterator2>
-brick_partition_copy(InputIterator first, InputIterator last, OutputIterator1 out_true, OutputIterator2 out_false, UnaryPredicate pred, /*is_vector=*/std::false_type) noexcept {
-    return std::partition_copy(first, last, out_true, out_false, pred);
+template<class _ForwardIterator, class _OutputIterator1, class _OutputIterator2, class _UnaryPredicate>
+std::pair<_OutputIterator1, _OutputIterator2>
+brick_partition_copy(_ForwardIterator __first, _ForwardIterator __last, _OutputIterator1 __out_true, _OutputIterator2 __out_false, _UnaryPredicate __pred, /*is_vector=*/std::false_type) noexcept {
+    return std::partition_copy(__first, __last, __out_true, __out_false, __pred);
 }
 
-template<class InputIterator, class OutputIterator1, class OutputIterator2, class UnaryPredicate>
-std::pair<OutputIterator1, OutputIterator2>
-brick_partition_copy(InputIterator first, InputIterator last, OutputIterator1 out_true, OutputIterator2 out_false, UnaryPredicate pred, /*is_vector=*/std::true_type) noexcept {
+template<class _ForwardIterator, class _OutputIterator1, class _OutputIterator2, class _UnaryPredicate>
+std::pair<_OutputIterator1, _OutputIterator2>
+brick_partition_copy(_ForwardIterator __first, _ForwardIterator __last, _OutputIterator1 __out_true, _OutputIterator2 __out_false, _UnaryPredicate __pred, /*is_vector=*/std::true_type) noexcept {
 #if (__PSTL_MONOTONIC_PRESENT)
-    return unseq_backend::simd_partition_copy(first, last - first, out_true, out_false, pred);
+    return unseq_backend::simd_partition_copy(__first, __last - __first, __out_true, __out_false, __pred);
 #else
-    return std::partition_copy(first, last, out_true, out_false, pred);
+    return std::partition_copy(__first, __last, __out_true, __out_false, __pred);
 #endif
 }
 
-
-template<class InputIterator, class OutputIterator1, class OutputIterator2, class UnaryPredicate, class IsVector>
-std::pair<OutputIterator1, OutputIterator2>
-pattern_partition_copy(InputIterator first, InputIterator last, OutputIterator1 out_true, OutputIterator2 out_false, UnaryPredicate pred, IsVector is_vector,/*is_parallelization=*/std::false_type) noexcept {
-    return brick_partition_copy(first, last, out_true, out_false, pred, is_vector);
+template<class _ForwardIterator, class _OutputIterator1, class _OutputIterator2, class _UnaryPredicate, class _IsVector>
+std::pair<_OutputIterator1, _OutputIterator2>
+pattern_partition_copy(_ForwardIterator __first, _ForwardIterator __last, _OutputIterator1 __out_true, _OutputIterator2 __out_false, _UnaryPredicate __pred, _IsVector __is_vector,/*is_parallelization=*/std::false_type) noexcept {
+    return internal::brick_partition_copy(__first, __last, __out_true, __out_false, __pred, __is_vector);
 }
 
-template<class InputIterator, class OutputIterator1, class OutputIterator2, class UnaryPredicate, class IsVector>
-std::pair<OutputIterator1, OutputIterator2>
-pattern_partition_copy(InputIterator first, InputIterator last, OutputIterator1 out_true, OutputIterator2 out_false, UnaryPredicate pred, IsVector is_vector, /*is_parallelization=*/std::true_type) noexcept {
-    typedef typename std::iterator_traits<InputIterator>::difference_type difference_type;
-    typedef std::pair<difference_type, difference_type> return_type;
-    const difference_type n = last - first;
-    if (difference_type(1) < n) {
-        par_backend::buffer<bool> mask_buf(n);
-        if (mask_buf) {
-            return except_handler([n, first, last, out_true, out_false, is_vector, pred, &mask_buf]() {
-                bool* mask = mask_buf.get();
-                return_type m;
-                par_backend::parallel_strict_scan(n, std::make_pair(difference_type(0), difference_type(0)),
-                    [=](difference_type i, difference_type len) {                             // Reduce
-                    return brick_calc_mask_1<difference_type>(first + i, first + (i + len),
-                        mask + i,
-                        pred,
-                        is_vector);
+template<class _RandomAccessIterator, class _OutputIterator1, class _OutputIterator2, class _UnaryPredicate, class _IsVector>
+std::pair<_OutputIterator1, _OutputIterator2>
+pattern_partition_copy(_RandomAccessIterator __first, _RandomAccessIterator __last, _OutputIterator1 __out_true, _OutputIterator2 __out_false, _UnaryPredicate __pred, _IsVector __is_vector, /*is_parallelization=*/std::true_type) noexcept {
+    typedef typename std::iterator_traits<_RandomAccessIterator>::difference_type _difference_type;
+    typedef std::pair<_difference_type, _difference_type> _return_type;
+    const _difference_type __n = __last - __first;
+    if (_difference_type(1) < __n) {
+        par_backend::buffer<bool> __mask_buf(__n);
+        if (__mask_buf) {
+            return internal::except_handler([__n, __first, __last, __out_true, __out_false, __is_vector, __pred, &__mask_buf]() {
+                bool* __mask = __mask_buf.get();
+                _return_type __m;
+                par_backend::parallel_strict_scan(__n, std::make_pair(_difference_type(0), _difference_type(0)),
+                    [=](_difference_type __i, _difference_type __len) {                             // Reduce
+                        return internal::brick_calc_mask_1<_difference_type>(__first + __i, __first + (__i + __len),
+                        __mask + __i,
+                        __pred,
+                        __is_vector);
                 },
-                    [](const return_type& x, const return_type& y)-> return_type {
-                    return std::make_pair(x.first + y.first, x.second + y.second);
+                    [](const _return_type& __x, const _return_type& __y)-> _return_type {
+                    return std::make_pair(__x.first + __y.first, __x.second + __y.second);
                 },                                                                            // Combine
-                    [=](difference_type i, difference_type len, return_type initial) {        // Scan
-                    brick_partition_by_mask(first + i, first + (i + len),
-                        out_true + initial.first,
-                        out_false + initial.second,
-                        mask + i,
-                        is_vector);
+                    [=](_difference_type __i, _difference_type __len, _return_type __initial) {        // Scan
+                        internal::brick_partition_by_mask(__first + __i, __first + (__i + __len),
+                        __out_true + __initial.first,
+                        __out_false + __initial.second,
+                        __mask + __i,
+                        __is_vector);
                 },
-                    [&m](return_type total) {m = total; });
-                return std::make_pair(out_true + m.first, out_false + m.second);
+                [&__m](_return_type __total) {__m = __total; });
+                return std::make_pair(__out_true + __m.first, __out_false + __m.second);
             });
         }
     }
     // Out of memory or trivial sequence - use serial algorithm
-    return brick_partition_copy(first, last, out_true, out_false, pred, is_vector);
+    return internal::brick_partition_copy(__first, __last, __out_true, __out_false, __pred, __is_vector);
 }
 
 //------------------------------------------------------------------------
 // sort
 //------------------------------------------------------------------------
 
-template<class RandomAccessIterator, class Compare, class IsVector, class IsMoveConstructible>
-void pattern_sort(RandomAccessIterator first, RandomAccessIterator last, Compare comp, IsVector /*is_vector*/, /*is_parallel=*/std::false_type, IsMoveConstructible) noexcept {
-    std::sort(first, last, comp);
+template<class _RandomAccessIterator, class _Compare, class _IsVector, class _IsMoveConstructible>
+void pattern_sort(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp, _IsVector /*is_vector*/, /*is_parallel=*/std::false_type, _IsMoveConstructible) noexcept {
+    std::sort(__first, __last, __comp);
 }
 
 
-template<class RandomAccessIterator, class Compare, class IsVector>
-void pattern_sort(RandomAccessIterator first, RandomAccessIterator last, Compare comp, IsVector /*is_vector*/, /*is_parallel=*/std::true_type, /*is_move_constructible=*/std::true_type ) {
-    except_handler([=]() {
-        par_backend::parallel_stable_sort(first, last, comp,
-            [](RandomAccessIterator first, RandomAccessIterator last, Compare comp) {
-            std::sort(first, last, comp);
-        });
+template<class _RandomAccessIterator, class _Compare, class _IsVector>
+void pattern_sort(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp, _IsVector /*is_vector*/, /*is_parallel=*/std::true_type, /*is_move_constructible=*/std::true_type ) {
+    internal::except_handler([=]() {
+        par_backend::parallel_stable_sort(__first, __last, __comp,
+            [](_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp) { std::sort(__first, __last, __comp); });
     });
 }
 
@@ -1262,17 +1275,17 @@ void pattern_sort(RandomAccessIterator first, RandomAccessIterator last, Compare
 // stable_sort
 //------------------------------------------------------------------------
 
-template<class RandomAccessIterator, class Compare, class IsVector>
-void pattern_stable_sort(RandomAccessIterator first, RandomAccessIterator last, Compare comp, IsVector /*is_vector*/, /*is_parallel=*/std::false_type) noexcept {
-    std::stable_sort(first, last, comp);
+template<class _RandomAccessIterator, class _Compare, class _IsVector>
+void pattern_stable_sort(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp, _IsVector /*is_vector*/, /*is_parallel=*/std::false_type) noexcept {
+    std::stable_sort(__first, __last, __comp);
 }
 
-template<class RandomAccessIterator, class Compare, class IsVector>
-void pattern_stable_sort(RandomAccessIterator first, RandomAccessIterator last, Compare comp, IsVector /*is_vector*/, /*is_parallel=*/std::true_type) {
-    except_handler([=]() {
-        par_backend::parallel_stable_sort(first, last, comp,
-            [](RandomAccessIterator first, RandomAccessIterator last, Compare comp) {
-            std::stable_sort(first, last, comp);
+template<class _RandomAccessIterator, class _Compare, class _IsVector>
+void pattern_stable_sort(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp, _IsVector /*is_vector*/, /*is_parallel=*/std::true_type) {
+    internal::except_handler([=]() {
+        par_backend::parallel_stable_sort(__first, __last, __comp,
+            [](_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp) {
+            std::stable_sort(__first, __last, __comp);
         });
     });
 }
@@ -1281,73 +1294,73 @@ void pattern_stable_sort(RandomAccessIterator first, RandomAccessIterator last, 
 // partial_sort
 //------------------------------------------------------------------------
 
-template<class RandomAccessIterator, class Compare, class IsVector>
-void pattern_partial_sort(RandomAccessIterator first, RandomAccessIterator middle, RandomAccessIterator last, Compare comp, IsVector, /*is_parallel=*/std::false_type) noexcept {
-    std::partial_sort(first, middle, last, comp);
+template<class _RandomAccessIterator, class _Compare, class _IsVector>
+void pattern_partial_sort(_RandomAccessIterator __first, _RandomAccessIterator __middle, _RandomAccessIterator __last, _Compare __comp, _IsVector, /*is_parallel=*/std::false_type) noexcept {
+    std::partial_sort(__first, __middle, __last, __comp);
 }
 
-template <class RandomAccessIterator, class Compare, class IsVector>
-void pattern_partial_sort(RandomAccessIterator first, RandomAccessIterator middle, RandomAccessIterator last, Compare comp, IsVector, /*is_parallel=*/std::true_type) noexcept {
-    par_backend::parallel_partial_sort(first, middle, last, comp);
+template <class _RandomAccessIterator, class _Compare, class _IsVector>
+void pattern_partial_sort(_RandomAccessIterator __first, _RandomAccessIterator __middle, _RandomAccessIterator __last, _Compare __comp, _IsVector, /*is_parallel=*/std::true_type) noexcept {
+    par_backend::parallel_partial_sort(__first, __middle, __last, __comp);
 }
 
 //------------------------------------------------------------------------
 // partial_sort_copy
 //------------------------------------------------------------------------
 
-template<class InputIterator, class RandomAccessIterator, class Compare>
-RandomAccessIterator brick_partial_sort_copy(InputIterator first, InputIterator last, RandomAccessIterator d_first, RandomAccessIterator d_last, Compare comp, /*is_vector*/std::false_type) noexcept {
-    return std::partial_sort_copy(first, last, d_first, d_last, comp);
+template<class _ForwardIterator, class _RandomAccessIterator, class _Compare>
+_RandomAccessIterator brick_partial_sort_copy(_ForwardIterator __first, _ForwardIterator __last, _RandomAccessIterator __d_first, _RandomAccessIterator __d_last, _Compare __comp, /*__is_vector*/std::false_type) noexcept {
+    return std::partial_sort_copy(__first, __last, __d_first, __d_last, __comp);
 }
 
-template<class InputIterator, class RandomAccessIterator, class Compare>
-RandomAccessIterator brick_partial_sort_copy(InputIterator first, InputIterator last, RandomAccessIterator d_first, RandomAccessIterator d_last, Compare comp, /*is_vector*/std::true_type) noexcept {
+template<class _ForwardIterator, class _RandomAccessIterator, class _Compare>
+_RandomAccessIterator brick_partial_sort_copy(_ForwardIterator __first, _ForwardIterator __last, _RandomAccessIterator __d_first, _RandomAccessIterator __d_last, _Compare __comp, /*__is_vector*/std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
-    return std::partial_sort_copy(first, last, d_first, d_last, comp);
+    return std::partial_sort_copy(__first, __last, __d_first, __d_last, __comp);
 }
 
-template<class InputIterator, class RandomAccessIterator, class Compare, class IsVector>
-RandomAccessIterator pattern_partial_sort_copy(InputIterator first, InputIterator last, RandomAccessIterator d_first, RandomAccessIterator d_last, Compare comp, IsVector is_vector, /*is_parallel=*/std::false_type) noexcept {
-    return brick_partial_sort_copy(first, last, d_first, d_last, comp, is_vector);
+template<class _ForwardIterator, class _RandomAccessIterator, class _Compare, class _IsVector>
+_RandomAccessIterator pattern_partial_sort_copy(_ForwardIterator __first, _ForwardIterator __last, _RandomAccessIterator __d_first, _RandomAccessIterator __d_last, _Compare __comp, _IsVector __is_vector, /*is_parallel=*/std::false_type) noexcept {
+    return internal::brick_partial_sort_copy(__first, __last, __d_first, __d_last, __comp, __is_vector);
 }
 
-template<class InputIterator, class RandomAccessIterator, class Compare, class IsVector>
-RandomAccessIterator pattern_partial_sort_copy(InputIterator first, InputIterator last, RandomAccessIterator d_first, RandomAccessIterator d_last, Compare comp, IsVector is_vector, /*is_parallel=*/std::true_type) noexcept {
+template<class _ForwardIterator, class _RandomAccessIterator, class _Compare, class _IsVector>
+_RandomAccessIterator pattern_partial_sort_copy(_ForwardIterator __first, _ForwardIterator __last, _RandomAccessIterator __d_first, _RandomAccessIterator __d_last, _Compare __comp, _IsVector __is_vector, /*is_parallel=*/std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Parallel algorithm unimplemented, redirected to serial");
-    return brick_partial_sort_copy(first, last, d_first, d_last, comp, is_vector);
+    return internal::brick_partial_sort_copy(__first, __last, __d_first, __d_last, __comp, __is_vector);
 }
 
 //------------------------------------------------------------------------
 // count
 //------------------------------------------------------------------------
-template<class ForwardIterator, class Predicate>
-typename std::iterator_traits<ForwardIterator>::difference_type
-brick_count(ForwardIterator first, ForwardIterator last, Predicate pred, /* is_vector = */ std::true_type) noexcept {
-    return unseq_backend::simd_count(first, last-first, pred);
+template<class _ForwardIterator, class _Predicate>
+typename std::iterator_traits<_ForwardIterator>::difference_type
+brick_count(_ForwardIterator __first, _ForwardIterator __last, _Predicate __pred, /* is_vector = */ std::true_type) noexcept {
+    return unseq_backend::simd_count(__first, __last-__first, __pred);
 }
 
-template<class ForwardIterator, class Predicate>
-typename std::iterator_traits<ForwardIterator>::difference_type
-brick_count(ForwardIterator first, ForwardIterator last, Predicate pred, /* is_vector = */ std::false_type) noexcept {
-    return std::count_if(first, last, pred);
+template<class _ForwardIterator, class _Predicate>
+typename std::iterator_traits<_ForwardIterator>::difference_type
+brick_count(_ForwardIterator __first, _ForwardIterator __last, _Predicate __pred, /* is_vector = */ std::false_type) noexcept {
+    return std::count_if(__first, __last, __pred);
 }
 
-template<class ForwardIterator, class Predicate, class IsVector>
-typename std::iterator_traits<ForwardIterator>::difference_type
-pattern_count(ForwardIterator first, ForwardIterator last, Predicate pred, /* is_parallel */ std::false_type, IsVector vec) noexcept {
-    return brick_count(first, last, pred, vec);
+template<class _ForwardIterator, class _Predicate, class _IsVector>
+typename std::iterator_traits<_ForwardIterator>::difference_type
+pattern_count(_ForwardIterator __first, _ForwardIterator __last, _Predicate __pred, /* is_parallel */ std::false_type, _IsVector __is_vector) noexcept {
+    return internal::brick_count(__first, __last, __pred, __is_vector);
 }
 
-template<class ForwardIterator, class Predicate, class IsVector>
-typename std::iterator_traits<ForwardIterator>::difference_type
-pattern_count(ForwardIterator first, ForwardIterator last, Predicate pred, /* is_parallel */ std::true_type, IsVector vec) {
-    typedef typename std::iterator_traits<ForwardIterator>::difference_type size_type;
-    return except_handler([=]() {
-        return par_backend::parallel_reduce(first, last, size_type(0),
-            [pred, vec](ForwardIterator begin, ForwardIterator end, size_type value)->size_type {
-            return value + brick_count(begin, end, pred, vec);
+template<class _ForwardIterator, class _Predicate, class _IsVector>
+typename std::iterator_traits<_ForwardIterator>::difference_type
+pattern_count(_ForwardIterator __first, _ForwardIterator __last, _Predicate __pred, /* is_parallel */ std::true_type, _IsVector __is_vector) {
+    typedef typename std::iterator_traits<_ForwardIterator>::difference_type _size_type;
+    return internal::except_handler([=]() {
+        return par_backend::parallel_reduce(__first, __last, _size_type(0),
+            [__pred, __is_vector](_ForwardIterator __begin, _ForwardIterator __end, _size_type __value) -> _size_type {
+                return __value + internal::brick_count(__begin, __end, __pred, __is_vector);
             },
-            std::plus<size_type>()
+            std::plus<_size_type>()
         );
     });
 }
@@ -1355,53 +1368,54 @@ pattern_count(ForwardIterator first, ForwardIterator last, Predicate pred, /* is
 //------------------------------------------------------------------------
 // adjacent_find
 //------------------------------------------------------------------------
-template<class ForwardIt, class BinaryPredicate>
-ForwardIt brick_adjacent_find(ForwardIt first, ForwardIt last, BinaryPredicate pred, /* IsVector = */ std::true_type, bool or_semantic) noexcept {
-    return unseq_backend::simd_adjacent_find(first, last, pred, or_semantic);
+template<class _ForwardIterator, class _BinaryPredicate>
+_ForwardIterator brick_adjacent_find(_ForwardIterator __first, _ForwardIterator __last, _BinaryPredicate __pred, /* IsVector = */ std::true_type, bool __or_semantic) noexcept {
+    return unseq_backend::simd_adjacent_find(__first, __last, __pred, __or_semantic);
 }
 
-template<class ForwardIt, class BinaryPredicate>
-ForwardIt brick_adjacent_find(ForwardIt first, ForwardIt last, BinaryPredicate pred, /* IsVector = */ std::false_type, bool or_semantic) noexcept {
-    return std::adjacent_find(first, last, pred);
+template<class _ForwardIterator, class _BinaryPredicate>
+_ForwardIterator brick_adjacent_find(_ForwardIterator __first, _ForwardIterator __last, _BinaryPredicate __pred, /* IsVector = */ std::false_type, bool __or_semantic) noexcept {
+    return std::adjacent_find(__first, __last, __pred);
 }
 
-template<class ForwardIt, class BinaryPredicate, class IsVector>
-ForwardIt pattern_adjacent_find(ForwardIt first, ForwardIt last, BinaryPredicate pred, /* is_parallel */ std::false_type, IsVector vec, bool or_semantic) noexcept {
-    return brick_adjacent_find(first, last, pred, vec, or_semantic);
+template<class _ForwardIterator, class _BinaryPredicate, class _IsVector>
+_ForwardIterator pattern_adjacent_find(_ForwardIterator __first, _ForwardIterator __last, _BinaryPredicate __pred, /* is_parallel */ std::false_type, _IsVector __is_vector, bool __or_semantic) noexcept {
+    return internal::brick_adjacent_find(__first, __last, __pred, __is_vector, __or_semantic);
 }
 
-template<class ForwardIt, class BinaryPredicate, class IsVector>
-ForwardIt pattern_adjacent_find(ForwardIt first, ForwardIt last, BinaryPredicate pred, /* is_parallel */ std::true_type, IsVector vec, bool or_semantic) {
-    if (last - first < 2)
-        return last;
+template<class _RandomAccessIterator, class _BinaryPredicate, class _IsVector>
+_RandomAccessIterator pattern_adjacent_find(_RandomAccessIterator __first, _RandomAccessIterator __last, _BinaryPredicate __pred, /* is_parallel */ std::true_type, _IsVector __is_vector, bool __or_semantic) {
+    if (__last - __first < 2)
+        return __last;
 
-    return except_handler([=]() {
-        return par_backend::parallel_reduce(first, last, last,
-            [last, pred, vec, or_semantic](ForwardIt begin, ForwardIt end, ForwardIt value)->ForwardIt {
+    return internal::except_handler([=]() {
+        return par_backend::parallel_reduce(__first, __last, __last,
+            [__last, __pred, __is_vector, __or_semantic](_RandomAccessIterator __begin, _RandomAccessIterator __end,
+                                                         _RandomAccessIterator __value) -> _RandomAccessIterator {
 
             // TODO: investigate performance benefits from the use of shared variable for the result,
-            // checking (compare_and_swap idiom) its value at first.
-            if (or_semantic && value < last) {//found
+            // checking (compare_and_swap idiom) its __value at __first.
+            if (__or_semantic && __value < __last) {//found
                 par_backend::cancel_execution();
-                return value;
+                return __value;
             }
 
-            if (value > begin) {
-                // modify end to check the predicate on the boundary values;
+            if (__value > __begin) {
+                // modify __end to check the predicate on the boundary __values;
                 // TODO: to use a custom range with boundaries overlapping
-                // TODO: investigate what if we remove "if" below and run algorithm on range [first, last-1)
-                // then check the pair [last-1, last)
-                if (end != last)
-                    ++end;
+                // TODO: investigate what if we remove "if" below and run algorithm on range [__first, __last-1)
+                // then check the pair [__last-1, __last)
+                if (__end != __last)
+                    ++__end;
 
-                //correct the global result iterator if the "brick" returns a local "last"
-                const ForwardIt res = brick_adjacent_find(begin, end, pred, vec, or_semantic);
-                if (res < end)
-                    value = res;
+                //correct the global result iterator if the "brick" returns a local "__last"
+                const _RandomAccessIterator __res = internal::brick_adjacent_find(__begin, __end, __pred, __is_vector, __or_semantic);
+                if (__res < __end)
+                    __value = __res;
             }
-            return value;
+            return __value;
         },
-            [](ForwardIt x, ForwardIt y)->ForwardIt { return x < y ? x : y; } //reduce a value
+            [](_RandomAccessIterator __x, _RandomAccessIterator __y) -> _RandomAccessIterator { return __x < __y ? __x : __y; } //reduce a __value
         );
     });
 }
@@ -1410,387 +1424,387 @@ ForwardIt pattern_adjacent_find(ForwardIt first, ForwardIt last, BinaryPredicate
 // nth_element
 //------------------------------------------------------------------------
 
-template<class RandomAccessIterator, class Compare>
-void brick_nth_element(RandomAccessIterator first, RandomAccessIterator nth, RandomAccessIterator last, Compare comp, /* is_vector = */ std::false_type) noexcept {
-    std::nth_element(first, nth, last, comp);
+template<class _RandomAccessIterator, class _Compare>
+void brick_nth_element(_RandomAccessIterator __first, _RandomAccessIterator __nth, _RandomAccessIterator __last, _Compare __comp, /* __is_vector = */ std::false_type) noexcept {
+    std::nth_element(__first, __nth, __last, __comp);
 }
 
-template<class RandomAccessIterator, class Compare>
-void brick_nth_element(RandomAccessIterator first, RandomAccessIterator nth, RandomAccessIterator last, Compare comp, /* is_vector = */ std::true_type) noexcept {
+template<class _RandomAccessIterator, class _Compare>
+void brick_nth_element(_RandomAccessIterator __first, _RandomAccessIterator __nth, _RandomAccessIterator __last, _Compare __comp, /* __is_vector = */ std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
-    std::nth_element(first, nth, last, comp);
+    std::nth_element(__first, __nth, __last, __comp);
 }
 
-template<class RandomAccessIterator, class Compare, class IsVector>
-void pattern_nth_element(RandomAccessIterator first, RandomAccessIterator nth, RandomAccessIterator last, Compare comp, IsVector is_vector, /*is_parallel=*/std::false_type) noexcept {
-    brick_nth_element(first, nth, last, comp, is_vector);
+template<class _RandomAccessIterator, class _Compare, class _IsVector>
+void pattern_nth_element(_RandomAccessIterator __first, _RandomAccessIterator __nth, _RandomAccessIterator __last, _Compare __comp, _IsVector __is_vector, /*is_parallel=*/std::false_type) noexcept {
+    internal::brick_nth_element(__first, __nth, __last, __comp, __is_vector);
 }
 
-template<class RandomAccessIterator, class Compare, class IsVector>
-void pattern_nth_element(RandomAccessIterator first, RandomAccessIterator nth, RandomAccessIterator last, Compare comp, IsVector is_vector, /*is_parallel=*/std::true_type) noexcept {
+template<class _RandomAccessIterator, class _Compare, class _IsVector>
+void pattern_nth_element(_RandomAccessIterator __first, _RandomAccessIterator __nth, _RandomAccessIterator __last, _Compare __comp, _IsVector __is_vector, /*is_parallel=*/std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Parallel algorithm unimplemented, redirected to serial");
-    brick_nth_element(first, nth, last, comp, is_vector);
+    internal::brick_nth_element(__first, __nth, __last, __comp, __is_vector);
 }
 
 //------------------------------------------------------------------------
 // fill, fill_n
 //------------------------------------------------------------------------
-template<class ForwardIterator, class T>
-void brick_fill(ForwardIterator first, ForwardIterator last, const T& value, /* is_vector = */ std::true_type) noexcept {
-    unseq_backend::simd_fill_n(first, last-first, value);
+template<class _ForwardIterator, class _Tp>
+void brick_fill(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value, /* __is_vector = */ std::true_type) noexcept {
+    unseq_backend::simd_fill_n(__first, __last - __first, __value);
 }
 
-template<class ForwardIterator, class T>
-void brick_fill(ForwardIterator first, ForwardIterator last, const T& value, /* is_vector = */std::false_type) noexcept {
-    std::fill(first, last, value);
+template<class _ForwardIterator, class _Tp>
+void brick_fill(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value, /* __is_vector = */std::false_type) noexcept {
+    std::fill(__first, __last, __value);
 }
 
-template<class ForwardIterator, class T, class IsVector>
-void pattern_fill(ForwardIterator first, ForwardIterator last, const T& value, /*is_parallel=*/std::false_type, IsVector vec) noexcept {
-    brick_fill(first, last, value, vec);
+template<class _ForwardIterator, class _Tp, class _IsVector>
+void pattern_fill(_ForwardIterator __first, _ForwardIterator __last, const _Tp& __value, /*is_parallel=*/std::false_type, _IsVector __is_vector) noexcept {
+    internal::brick_fill(__first, __last, __value, __is_vector);
 }
 
-template<class ForwardIterator, class T, class IsVector>
-ForwardIterator pattern_fill(ForwardIterator first, ForwardIterator last, const T& value, /*is_parallel=*/std::true_type, IsVector vec) {
-    return except_handler([first, last, &value, vec]() {
-        par_backend::parallel_for(first, last, [&value, vec](ForwardIterator begin, ForwardIterator end) {
-            brick_fill(begin, end, value, vec); });
-        return last;
+template<class _ForwardIterator, class T, class _IsVector>
+_ForwardIterator pattern_fill(_ForwardIterator __first, _ForwardIterator __last, const T& __value, /*is_parallel=*/std::true_type, _IsVector __is_vector) {
+    return except_handler([__first, __last, &__value, __is_vector]() {
+        par_backend::parallel_for(__first, __last, [&__value, __is_vector](_ForwardIterator __begin, _ForwardIterator __end) {
+            internal::brick_fill(__begin, __end, __value, __is_vector); });
+        return __last;
     });
 }
 
-template<class OutputIterator, class Size, class T>
-OutputIterator brick_fill_n(OutputIterator first, Size count, const T& value, /* is_vector = */ std::true_type) noexcept {
-    return unseq_backend::simd_fill_n(first, count, value);
+template<class _OutputIterator, class _Size, class _Tp>
+_OutputIterator brick_fill_n(_OutputIterator __first, _Size __count, const _Tp& __value, /* __is_vector = */ std::true_type) noexcept {
+    return unseq_backend::simd_fill_n(__first, __count, __value);
 }
 
-template<class OutputIterator, class Size, class T>
-OutputIterator brick_fill_n(OutputIterator first, Size count, const T& value, /* is_vector = */ std::false_type) noexcept {
-    return std::fill_n(first, count, value);
+template<class _OutputIterator, class _Size, class _Tp>
+_OutputIterator brick_fill_n(_OutputIterator __first, _Size __count, const _Tp& __value, /* __is_vector = */ std::false_type) noexcept {
+    return std::fill_n(__first, __count, __value);
 }
 
-template<class OutputIterator, class Size, class T, class IsVector>
-OutputIterator pattern_fill_n(OutputIterator first, Size count, const T& value, /*is_parallel=*/std::false_type, IsVector vec) noexcept {
-    return brick_fill_n(first, count, value, vec);
+template<class _OutputIterator, class _Size, class _Tp, class _IsVector>
+_OutputIterator pattern_fill_n(_OutputIterator __first, _Size __count, const _Tp& __value, /*is_parallel=*/std::false_type, _IsVector __is_vector) noexcept {
+    return internal::brick_fill_n(__first, __count, __value, __is_vector);
 }
 
-template<class OutputIterator, class Size, class T, class IsVector>
-OutputIterator pattern_fill_n(OutputIterator first, Size count, const T& value, /*is_parallel=*/std::true_type, IsVector vec) {
-    return pattern_fill(first, first + count, value, std::true_type(), vec);
+template<class _OutputIterator, class _Size, class _Tp, class _IsVector>
+_OutputIterator pattern_fill_n(_OutputIterator __first, _Size __count, const _Tp& __value, /*is_parallel=*/std::true_type, _IsVector __is_vector) {
+    return internal::pattern_fill(__first, __first + __count, __value, std::true_type(), __is_vector);
 }
 
 //------------------------------------------------------------------------
 // generate, generate_n
 //------------------------------------------------------------------------
-template<class ForwardIterator, class Generator>
-void brick_generate(ForwardIterator first, ForwardIterator last, Generator g, /* is_vector = */ std::true_type) noexcept {
-    unseq_backend::simd_generate_n(first, last-first, g);
+template<class _RandomAccessIterator, class _Generator>
+void brick_generate(_RandomAccessIterator __first, _RandomAccessIterator __last, _Generator __g, /* is_vector = */ std::true_type) noexcept {
+    unseq_backend::simd_generate_n(__first, __last-__first, __g);
 }
 
-template<class ForwardIterator, class Generator>
-void brick_generate(ForwardIterator first, ForwardIterator last, Generator g, /* is_vector = */std::false_type) noexcept {
-    std::generate(first, last, g);
+template<class _ForwardIterator, class _Generator>
+void brick_generate(_ForwardIterator __first, _ForwardIterator __last, _Generator __g, /* is_vector = */std::false_type) noexcept {
+    std::generate(__first, __last, __g);
 }
 
-template<class ForwardIterator, class Generator, class IsVector>
-void pattern_generate(ForwardIterator first, ForwardIterator last, Generator g, /*is_parallel=*/std::false_type, IsVector vec) noexcept {
-    brick_generate(first, last, g, vec);
+template<class _ForwardIterator, class _Generator, class _IsVector>
+void pattern_generate(_ForwardIterator __first, _ForwardIterator __last, _Generator __g, /*is_parallel=*/std::false_type, _IsVector __is_vector) noexcept {
+    internal::brick_generate(__first, __last, __g, __is_vector);
 }
 
-template<class ForwardIterator, class Generator, class IsVector>
-ForwardIterator pattern_generate(ForwardIterator first, ForwardIterator last, Generator g, /*is_parallel=*/std::true_type, IsVector vec) {
-    return except_handler([=]() {
-        par_backend::parallel_for(first, last, [g, vec](ForwardIterator begin, ForwardIterator end) {
-            brick_generate(begin, end, g, vec); });
-        return last;
+template<class _ForwardIterator, class _Generator, class _IsVector>
+_ForwardIterator pattern_generate(_ForwardIterator __first, _ForwardIterator __last, _Generator __g, /*is_parallel=*/std::true_type, _IsVector __is_vector) {
+    return internal::except_handler([=]() {
+        par_backend::parallel_for(__first, __last, [__g, __is_vector](_ForwardIterator __begin, _ForwardIterator __end) {
+            internal::brick_generate(__begin, __end, __g, __is_vector); });
+        return __last;
     });
 }
 
-template<class OutputIterator, class Size, class Generator>
-OutputIterator brick_generate_n(OutputIterator first, Size count, Generator g, /* is_vector = */ std::true_type) noexcept {
-    return unseq_backend::simd_generate_n(first, count, g);
+template<class OutputIterator, class Size, class _Generator>
+OutputIterator brick_generate_n(OutputIterator __first, Size __count, _Generator __g, /* is_vector = */ std::true_type) noexcept {
+    return unseq_backend::simd_generate_n(__first, __count, __g);
 }
 
-template<class OutputIterator, class Size, class Generator>
-OutputIterator brick_generate_n(OutputIterator first, Size count, Generator g, /* is_vector = */ std::false_type) noexcept {
-    return std::generate_n(first, count, g);
+template<class OutputIterator, class Size, class _Generator>
+OutputIterator brick_generate_n(OutputIterator __first, Size __count, _Generator __g, /* is_vector = */ std::false_type) noexcept {
+    return std::generate_n(__first, __count, __g);
 }
 
-template<class OutputIterator, class Size, class Generator, class IsVector>
-OutputIterator pattern_generate_n(OutputIterator first, Size count, Generator g, /*is_parallel=*/std::false_type, IsVector vec) noexcept {
-    return brick_generate_n(first, count, g, vec);
+template<class OutputIterator, class Size, class _Generator, class _IsVector>
+OutputIterator pattern_generate_n(OutputIterator __first, Size __count, _Generator __g, /*is_parallel=*/std::false_type, _IsVector __is_vector) noexcept {
+    return internal::brick_generate_n(__first, __count, __g, __is_vector);
 }
 
-template<class OutputIterator, class Size, class Generator, class IsVector>
-OutputIterator pattern_generate_n(OutputIterator first, Size count, Generator g, /*is_parallel=*/std::true_type, IsVector vec) {
-    return pattern_generate(first, first + count, g, std::true_type(), vec);
+template<class OutputIterator, class Size, class _Generator, class _IsVector>
+OutputIterator pattern_generate_n(OutputIterator __first, Size __count, _Generator __g, /*is_parallel=*/std::true_type, _IsVector __is_vector) {
+  // BUG? - This assumes that an OutputIterator supports operator+()
+    return internal::pattern_generate(__first, __first + __count, __g, std::true_type(), __is_vector);
 }
 
 //------------------------------------------------------------------------
 // remove
 //------------------------------------------------------------------------
 
-template<class ForwardIterator, class UnaryPredicate>
-ForwardIterator brick_remove_if(ForwardIterator first, ForwardIterator last, UnaryPredicate pred, /* is_vector = */ std::false_type) noexcept {
-    return std::remove_if(first, last, pred);
+template<class _ForwardIterator, class _UnaryPredicate>
+_ForwardIterator brick_remove_if(_ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred, /* __is_vector = */ std::false_type) noexcept {
+    return std::remove_if(__first, __last, __pred);
 }
 
-template<class ForwardIterator, class UnaryPredicate>
-ForwardIterator brick_remove_if(ForwardIterator first, ForwardIterator last, UnaryPredicate pred, /* is_vector = */ std::true_type) noexcept {
-    return unseq_backend::simd_remove_if(first, last - first, pred);
+template<class _RandomAccessIterator, class _UnaryPredicate>
+_RandomAccessIterator brick_remove_if(_RandomAccessIterator __first, _RandomAccessIterator __last, _UnaryPredicate __pred, /* __is_vector = */ std::true_type) noexcept {
+    return unseq_backend::simd_remove_if(__first, __last - __first, __pred);
 }
 
-template<class ForwardIterator, class UnaryPredicate, class IsVector>
-ForwardIterator pattern_remove_if(ForwardIterator first, ForwardIterator last, UnaryPredicate pred, IsVector is_vector, /*is_parallel*/ std::false_type) noexcept {
-    return brick_remove_if(first, last, pred, is_vector);
+template<class _ForwardIterator, class _UnaryPredicate, class _IsVector>
+_ForwardIterator pattern_remove_if(_ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred, _IsVector __is_vector, /*is_parallel*/ std::false_type) noexcept {
+    return internal::brick_remove_if(__first, __last, __pred, __is_vector);
 }
 
-template<class ForwardIterator, class UnaryPredicate, class IsVector>
-ForwardIterator pattern_remove_if(ForwardIterator first, ForwardIterator last, UnaryPredicate pred, IsVector is_vector, /*is_parallel*/ std::true_type) noexcept {
+template<class _ForwardIterator, class _UnaryPredicate, class _IsVector>
+_ForwardIterator pattern_remove_if(_ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred, _IsVector __is_vector, /*is_parallel*/ std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Parallel algorithm unimplemented, redirected to serial");
-    return brick_remove_if(first, last, pred, is_vector);
+    return internal::brick_remove_if(__first, __last, __pred, __is_vector);
 }
 
 //------------------------------------------------------------------------
 // merge
 //------------------------------------------------------------------------
 
-template<class InputIterator1, class InputIterator2, class OutputIterator, class Compare>
-OutputIterator brick_merge(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, OutputIterator d_first, Compare comp, /* is_vector = */ std::false_type) noexcept {
-    return std::merge(first1, last1, first2, last2, d_first, comp);
+template<class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator, class _Compare>
+_OutputIterator brick_merge(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2, _OutputIterator __d_first, _Compare __comp, /* __is_vector = */ std::false_type) noexcept {
+    return std::merge(__first1, __last1, __first2, __last2, __d_first, __comp);
 }
 
-template<class InputIterator1, class InputIterator2, class OutputIterator, class Compare>
-OutputIterator brick_merge(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, OutputIterator d_first, Compare comp, /* is_vector = */ std::true_type) noexcept {
+template<class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator, class _Compare>
+_OutputIterator brick_merge(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2, _OutputIterator __d_first, _Compare __comp, /* __is_vector = */ std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
-    return std::merge(first1, last1, first2, last2, d_first, comp);
+    return std::merge(__first1, __last1, __first2, __last2, __d_first, __comp);
 }
 
-template<class InputIterator1, class InputIterator2, class OutputIterator, class Compare, class IsVector>
-OutputIterator pattern_merge(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, OutputIterator d_first, Compare comp, IsVector is_vector, /* is_parallel = */ std::false_type) noexcept {
-    return brick_merge(first1, last1, first2, last2, d_first, comp, is_vector);
+template<class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator, class _Compare, class _IsVector>
+_OutputIterator pattern_merge(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2, _OutputIterator __d_first, _Compare __comp, _IsVector __is_vector, /* is_parallel = */ std::false_type) noexcept {
+    return internal::brick_merge(__first1, __last1, __first2, __last2, __d_first, __comp, __is_vector);
 }
 
-template<class InputIterator1, class InputIterator2, class OutputIterator, class Compare, class IsVector>
-OutputIterator pattern_merge(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, OutputIterator d_first, Compare comp, IsVector is_vector, /* is_parallel = */ std::true_type) noexcept {
-    par_backend::parallel_merge(first1, last1, first2, last2, d_first, comp,
-        [is_vector](InputIterator1 f1, InputIterator1 l1, InputIterator2 f2, InputIterator2 l2, OutputIterator f3, Compare comp) {return brick_merge(f1, l1, f2, l2, f3, comp, is_vector); });
-    return d_first + (last1 - first1) + (last2 - first2);
+template<class _RandomAccessIterator1, class _RandomAccessIterator2, class _OutputIterator, class _Compare, class _IsVector>
+_OutputIterator pattern_merge(_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2, _RandomAccessIterator2 __last2, _OutputIterator __d_first, _Compare __comp, _IsVector __is_vector, /* is_parallel = */ std::true_type) noexcept {
+    par_backend::parallel_merge(__first1, __last1, __first2, __last2, __d_first, __comp,
+        [__is_vector](_RandomAccessIterator1 __f1, _RandomAccessIterator1 __l1, _RandomAccessIterator2 __f2, _RandomAccessIterator2 __l2, _OutputIterator __f3, _Compare __comp) {return brick_merge(__f1, __l1, __f2, __l2, __f3, __comp, __is_vector); });
+    return __d_first + (__last1 - __first1) + (__last2 - __first2);
 }
 
 //------------------------------------------------------------------------
 // inplace_merge
 //------------------------------------------------------------------------
-template<class BidirectionalIterator, class Compare>
-void brick_inplace_merge(BidirectionalIterator first, BidirectionalIterator middle, BidirectionalIterator last, Compare comp, /* is_vector = */ std::false_type) noexcept {
-    std::inplace_merge(first, middle, last, comp);
+template<class _BidirectionalIterator, class _Compare>
+void brick_inplace_merge(_BidirectionalIterator __first, _BidirectionalIterator __middle, _BidirectionalIterator __last, _Compare __comp, /* __is_vector = */ std::false_type) noexcept {
+    std::inplace_merge(__first, __middle, __last, __comp);
 }
 
-template<class BidirectionalIterator, class Compare>
-void brick_inplace_merge(BidirectionalIterator first, BidirectionalIterator middle, BidirectionalIterator last, Compare comp, /* is_vector = */ std::true_type) noexcept {
+template<class _BidirectionalIterator, class _Compare>
+void brick_inplace_merge(_BidirectionalIterator __first, _BidirectionalIterator __middle, _BidirectionalIterator __last, _Compare __comp, /* __is_vector = */ std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial")
-        std::inplace_merge(first, middle, last, comp);
+        std::inplace_merge(__first, __middle, __last, __comp);
 }
 
-template<class BidirectionalIterator, class Compare, class IsVector>
-void pattern_inplace_merge(BidirectionalIterator first, BidirectionalIterator middle, BidirectionalIterator last, Compare comp, IsVector is_vector, /* is_parallel = */ std::false_type) noexcept {
-    brick_inplace_merge(first, middle, last, comp, is_vector);
+template<class _BidirectionalIterator, class _Compare, class _IsVector>
+void pattern_inplace_merge(_BidirectionalIterator __first, _BidirectionalIterator __middle, _BidirectionalIterator __last, _Compare __comp, _IsVector __is_vector, /* is_parallel = */ std::false_type) noexcept {
+    internal::brick_inplace_merge(__first, __middle, __last, __comp, __is_vector);
 }
 
-template<class BidirectionalIterator, class Compare, class IsVector>
-void pattern_inplace_merge(BidirectionalIterator first, BidirectionalIterator middle, BidirectionalIterator last, Compare comp, IsVector is_vector, /*is_parallel=*/std::true_type) noexcept {
+template<class _BidirectionalIterator, class _Compare, class _IsVector>
+void pattern_inplace_merge(_BidirectionalIterator __first, _BidirectionalIterator __middle, _BidirectionalIterator __last, _Compare __comp, _IsVector __is_vector, /*is_parallel=*/std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Parallel algorithm unimplemented, redirected to serial");
-    brick_inplace_merge(first, middle, last, comp, is_vector);
+    internal::brick_inplace_merge(__first, __middle, __last, __comp, __is_vector);
 }
 
 //------------------------------------------------------------------------
 // includes
 //------------------------------------------------------------------------
 
-template<class InputIterator1, class InputIterator2, class Compare>
-bool brick_includes(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, Compare comp, /* IsVector = */ std::false_type) noexcept {
-    return std::includes(first1, last1, first2, last2, comp);
+template<class ForwardIterator1, class ForwardIterator2, class _Compare>
+bool brick_includes(ForwardIterator1 __first1, ForwardIterator1 __last1, ForwardIterator2 __first2, ForwardIterator2 __last2, _Compare __comp, /* _IsVector = */ std::false_type) noexcept {
+    return std::includes(__first1, __last1, __first2, __last2, __comp);
 }
 
-template<class InputIterator1, class InputIterator2, class Compare>
-bool brick_includes(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, Compare comp, /* IsVector = */ std::true_type) noexcept {
+template<class ForwardIterator1, class ForwardIterator2, class _Compare>
+bool brick_includes(ForwardIterator1 __first1, ForwardIterator1 __last1, ForwardIterator2 __first2, ForwardIterator2 __last2, _Compare __comp, /* _IsVector = */ std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial")
-        return std::includes(first1, last1, first2, last2, comp);
+        return std::includes(__first1, __last1, __first2, __last2, __comp);
 }
 
-template<class InputIterator1, class InputIterator2, class Compare, class IsVector>
-bool pattern_includes(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, Compare comp, IsVector is_vector, /*is_parallel=*/std::false_type) noexcept {
-    return brick_includes(first1, last1, first2, last2, comp, is_vector);
+template<class ForwardIterator1, class ForwardIterator2, class _Compare, class _IsVector>
+bool pattern_includes(ForwardIterator1 __first1, ForwardIterator1 __last1, ForwardIterator2 __first2, ForwardIterator2 __last2, _Compare __comp, _IsVector __is_vector, /*is_parallel=*/std::false_type) noexcept {
+    return internal::brick_includes(__first1, __last1, __first2, __last2, __comp, __is_vector);
 }
 
-template<class InputIterator1, class InputIterator2, class Compare, class IsVector>
-bool pattern_includes(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, Compare comp, IsVector is_vector, /*is_parallel=*/std::true_type) noexcept {
+template<class ForwardIterator1, class ForwardIterator2, class _Compare, class _IsVector>
+bool pattern_includes(ForwardIterator1 __first1, ForwardIterator1 __last1, ForwardIterator2 __first2, ForwardIterator2 __last2, _Compare __comp, _IsVector __is_vector, /*is_parallel=*/std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Parallel algorithm unimplemented, redirected to serial");
-    return brick_includes(first1, last1, first2, last2, comp, is_vector);
+    return internal::brick_includes(__first1, __last1, __first2, __last2, __comp, __is_vector);
 }
 
 //------------------------------------------------------------------------
 // set_union
 //------------------------------------------------------------------------
 
-template<class InputIterator1, class InputIterator2, class OutputIterator, class Compare>
-OutputIterator brick_set_union(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, OutputIterator result, Compare comp, /*is_vector=*/std::false_type) noexcept {
-    return std::set_union(first1, last1, first2, last2, result, comp);
+template<class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator, class _Compare>
+_OutputIterator brick_set_union(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp, /*__is_vector=*/std::false_type) noexcept {
+    return std::set_union(__first1, __last1, __first2, __last2, __result, __comp);
 }
 
-template<class InputIterator1, class InputIterator2, class OutputIterator, class Compare>
-OutputIterator brick_set_union(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2,
-    InputIterator2 last2, OutputIterator result, Compare comp, /*is_vector=*/std::true_type) noexcept {
+template<class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator, class _Compare>
+_OutputIterator brick_set_union(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+    _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp, /*__is_vector=*/std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
-    return std::set_union(first1, last1, first2, last2, result, comp);
+    return std::set_union(__first1, __last1, __first2, __last2, __result, __comp);
 }
 
-template<class InputIterator1, class InputIterator2, class OutputIterator, class Compare, class IsVector>
-OutputIterator pattern_set_union(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, OutputIterator result, Compare comp, IsVector is_vector, /*is_parallel=*/std::false_type) noexcept {
-    return brick_set_union(first1, last1, first2, last2, result, comp, is_vector);
+template<class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator, class _Compare, class _IsVector>
+_OutputIterator pattern_set_union(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp, _IsVector __is_vector, /*is_parallel=*/std::false_type) noexcept {
+    return internal::brick_set_union(__first1, __last1, __first2, __last2, __result, __comp, __is_vector);
 }
 
-template<class InputIterator1, class InputIterator2, class OutputIterator, class Compare, class IsVector>
-OutputIterator pattern_set_union(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, OutputIterator result, Compare comp, IsVector is_vector, /*is_parallel=*/std::true_type) noexcept {
+template<class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator, class _Compare, class _IsVector>
+_OutputIterator pattern_set_union(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp, _IsVector __is_vector, /*is_parallel=*/std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Parallel algorithm unimplemented, redirected to serial");
-    return brick_set_union(first1, last1, first2, last2, result, comp, is_vector);
+    return internal::brick_set_union(__first1, __last1, __first2, __last2, __result, __comp, __is_vector);
 }
 
 //------------------------------------------------------------------------
 // set_intersection
 //------------------------------------------------------------------------
 
-template<class InputIterator1, class InputIterator2, class OutputIterator, class Compare>
-OutputIterator brick_set_intersection(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, OutputIterator result, Compare comp, /*is_vector=*/std::false_type) noexcept {
-    return std::set_intersection(first1, last1, first2, last2, result, comp);
+template<class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator, class _Compare>
+_OutputIterator brick_set_intersection(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp, /*__is_vector=*/std::false_type) noexcept {
+    return std::set_intersection(__first1, __last1, __first2, __last2, __result, __comp);
 }
 
-template<class InputIterator1, class InputIterator2, class OutputIterator, class Compare>
-OutputIterator brick_set_intersection(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, OutputIterator result, Compare comp, /*is_vector=*/std::true_type) noexcept {
+template<class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator, class _Compare>
+_OutputIterator brick_set_intersection(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp, /*__is_vector=*/std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
-    return std::set_intersection(first1, last1, first2, last2, result, comp);
+    return std::set_intersection(__first1, __last1, __first2, __last2, __result, __comp);
 }
 
-template<class InputIterator1, class InputIterator2, class OutputIterator, class Compare, class IsVector>
-OutputIterator pattern_set_intersection(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, OutputIterator result, Compare comp, IsVector is_vector, /*is_parallel=*/std::false_type) noexcept {
-    return brick_set_intersection(first1, last1, first2, last2, result, comp, is_vector);
+template<class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator, class _Compare, class _IsVector>
+_OutputIterator pattern_set_intersection(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp, _IsVector __is_vector, /*is_parallel=*/std::false_type) noexcept {
+    return internal::brick_set_intersection(__first1, __last1, __first2, __last2, __result, __comp, __is_vector);
 }
 
-template<class InputIterator1, class InputIterator2, class OutputIterator, class Compare, class IsVector>
-OutputIterator pattern_set_intersection(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, OutputIterator result, Compare comp, IsVector is_vector, /*is_parallel=*/std::true_type) noexcept {
+template<class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator, class _Compare, class _IsVector>
+_OutputIterator pattern_set_intersection(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp, _IsVector __is_vector, /*is_parallel=*/std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Parallel algorithm unimplemented, redirected to serial");
-    return brick_set_intersection(first1, last1, first2, last2, result, comp, is_vector);
+    return internal::brick_set_intersection(__first1, __last1, __first2, __last2, __result, __comp, __is_vector);
 }
 
 //------------------------------------------------------------------------
 // set_difference
 //------------------------------------------------------------------------
 
-template<class InputIterator1, class InputIterator2, class OutputIterator, class Compare>
-OutputIterator brick_set_difference(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, OutputIterator result, Compare comp, /*is_vector=*/std::false_type) noexcept {
-    return std::set_difference(first1, last1, first2, last2, result, comp);
+template<class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator, class _Compare>
+_OutputIterator brick_set_difference(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp, /*__is_vector=*/std::false_type) noexcept {
+    return std::set_difference(__first1, __last1, __first2, __last2, __result, __comp);
 }
 
-template<class InputIterator1, class InputIterator2, class OutputIterator, class Compare>
-OutputIterator brick_set_difference(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, OutputIterator result, Compare comp, /*is_vector=*/std::true_type) noexcept {
+template<class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator, class _Compare>
+_OutputIterator brick_set_difference(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp, /*__is_vector=*/std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
-    return std::set_difference(first1, last1, first2, last2, result, comp);
+    return std::set_difference(__first1, __last1, __first2, __last2, __result, __comp);
 }
 
-template<class InputIterator1, class InputIterator2, class OutputIterator, class Compare, class IsVector>
-OutputIterator pattern_set_difference(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, OutputIterator result, Compare comp, IsVector is_vector, /*is_parallel=*/std::false_type) noexcept {
-    return brick_set_difference(first1, last1, first2, last2, result, comp, is_vector);
+template<class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator, class _Compare, class _IsVector>
+_OutputIterator pattern_set_difference(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp, _IsVector __is_vector, /*is_parallel=*/std::false_type) noexcept {
+    return internal::brick_set_difference(__first1, __last1, __first2, __last2, __result, __comp, __is_vector);
 }
 
-template<class InputIterator1, class InputIterator2, class OutputIterator, class Compare, class IsVector>
-OutputIterator pattern_set_difference(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, OutputIterator result, Compare comp, IsVector is_vector, /*is_parallel=*/std::true_type) noexcept {
+template<class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator, class _Compare, class _IsVector>
+_OutputIterator pattern_set_difference(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp, _IsVector __is_vector, /*is_parallel=*/std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Parallel algorithm unimplemented, redirected to serial");
-    return brick_set_difference(first1, last1, first2, last2, result, comp, is_vector);
+    return internal::brick_set_difference(__first1, __last1, __first2, __last2, __result, __comp, __is_vector);
 }
 
 //------------------------------------------------------------------------
 // set_symmetric_difference
 //------------------------------------------------------------------------
 
-template<class InputIterator1, class InputIterator2, class OutputIterator, class Compare>
-OutputIterator brick_set_symmetric_difference(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, OutputIterator result, Compare comp,/*is_vector=*/std::false_type) noexcept {
-    return std::set_symmetric_difference(first1, last1, first2, last2, result, comp);
+template<class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator, class _Compare>
+_OutputIterator brick_set_symmetric_difference(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp,/*__is_vector=*/std::false_type) noexcept {
+    return std::set_symmetric_difference(__first1, __last1, __first2, __last2, __result, __comp);
 }
 
-template<class InputIterator1, class InputIterator2, class OutputIterator, class Compare>
-OutputIterator brick_set_symmetric_difference(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, OutputIterator result, Compare comp, /*is_vector=*/std::true_type) noexcept {
+template<class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator, class _Compare>
+_OutputIterator brick_set_symmetric_difference(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp, /*__is_vector=*/std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
-    return std::set_symmetric_difference(first1, last1, first2, last2, result, comp);
+    return std::set_symmetric_difference(__first1, __last1, __first2, __last2, __result, __comp);
 }
 
-template<class InputIterator1, class InputIterator2, class OutputIterator, class Compare, class IsVector>
-OutputIterator pattern_set_symmetric_difference(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, OutputIterator result, Compare comp, IsVector is_vector, /*is_parallel=*/std::false_type) noexcept {
-    return brick_set_symmetric_difference(first1, last1, first2, last2, result, comp, is_vector);
+template<class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator, class _Compare, class _IsVector>
+_OutputIterator pattern_set_symmetric_difference(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp, _IsVector __is_vector, /*is_parallel=*/std::false_type) noexcept {
+    return internal::brick_set_symmetric_difference(__first1, __last1, __first2, __last2, __result, __comp, __is_vector);
 }
 
-template<class InputIterator1, class InputIterator2, class OutputIterator, class Compare, class IsVector>
-OutputIterator pattern_set_symmetric_difference(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, OutputIterator result, Compare comp, IsVector is_vector, /*is_parallel=*/std::true_type) noexcept {
+template<class _ForwardIterator1, class _ForwardIterator2, class _OutputIterator, class _Compare, class _IsVector>
+_OutputIterator pattern_set_symmetric_difference(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2, _OutputIterator __result, _Compare __comp, _IsVector __is_vector, /*is_parallel=*/std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Parallel algorithm unimplemented, redirected to serial");
-    return brick_set_symmetric_difference(first1, last1, first2, last2, result, comp, is_vector);
+    return internal::brick_set_symmetric_difference(__first1, __last1, __first2, __last2, __result, __comp, __is_vector);
 }
 
 //------------------------------------------------------------------------
 // is_heap_until
 //------------------------------------------------------------------------
 
-template<class RandomAccessIterator, class Compare>
-RandomAccessIterator brick_is_heap_until(RandomAccessIterator first, RandomAccessIterator last, Compare comp,
-    /* is_vector = */ std::false_type) noexcept {
-    return std::is_heap_until(first, last, comp);
+template<class _RandomAccessIterator, class _Compare>
+_RandomAccessIterator brick_is_heap_until(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
+    /* __is_vector = */ std::false_type) noexcept {
+    return std::is_heap_until(__first, __last, __comp);
 }
 
-template<class RandomAccessIterator, class Compare>
-RandomAccessIterator brick_is_heap_until(RandomAccessIterator first, RandomAccessIterator last, Compare comp,
-    /* is_vector = */ std::true_type) noexcept {
-    if (last - first < 2)
-        return last;
-    typedef typename std::iterator_traits<RandomAccessIterator>::difference_type size_type;
-    return unseq_backend::simd_first(first, size_type(0), last - first,
-        [&comp](RandomAccessIterator it, size_type i) {return comp(it[(i - 1) / 2], it[i]); });
+template<class _RandomAccessIterator, class _Compare>
+_RandomAccessIterator brick_is_heap_until(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
+    /* __is_vector = */ std::true_type) noexcept {
+    if (__last - __first < 2)
+        return __last;
+    typedef typename std::iterator_traits<_RandomAccessIterator>::difference_type _size_type;
+    return unseq_backend::simd_first(__first, _size_type(0), __last - __first,
+        [&__comp](_RandomAccessIterator __it, _size_type __i) {return __comp(__it[(__i - 1) / 2], __it[__i]); });
 }
 
-template<class RandomAccessIterator, class Compare, class IsVector>
-RandomAccessIterator pattern_is_heap_until(RandomAccessIterator first, RandomAccessIterator last, Compare comp,
-    IsVector vec, /* is_parallel = */ std::false_type) noexcept {
-    return brick_is_heap_until(first, last, comp, vec);
+template<class _RandomAccessIterator, class _Compare, class _IsVector>
+_RandomAccessIterator pattern_is_heap_until(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
+    _IsVector __is_vector, /* is_parallel = */ std::false_type) noexcept {
+    return internal::brick_is_heap_until(__first, __last, __comp, __is_vector);
 }
 
-template<class RandomAccessIterator, class DifferenceType, class Compare>
-RandomAccessIterator is_heap_until_local(RandomAccessIterator first, DifferenceType begin, DifferenceType end, Compare comp,
-    /* is_vector = */ std::false_type) noexcept {
-    DifferenceType i = begin;
-    for (; i < end; ++i) {
-        if (comp(first[(i - 1) / 2], first[i])) {
+template<class _RandomAccessIterator, class _DifferenceType, class _Compare>
+_RandomAccessIterator is_heap_until_local(_RandomAccessIterator __first, _DifferenceType __begin, _DifferenceType __end, _Compare __comp,
+    /* __is_vector = */ std::false_type) noexcept {
+    _DifferenceType __i = __begin;
+    for (; __i < __end; ++__i) {
+        if (__comp(__first[(__i - 1) / 2], __first[__i])) {
             break;
         }
     }
-    return first + i;
+    return __first + __i;
 }
 
-template<class RandomAccessIterator, class DifferenceType, class Compare>
-RandomAccessIterator is_heap_until_local(RandomAccessIterator first, DifferenceType begin, DifferenceType end, Compare comp,
-    /* is_vector = */ std::true_type) noexcept {
-    return unseq_backend::simd_first(first, begin, end,
-        [&comp](RandomAccessIterator it, DifferenceType i) {return comp(it[(i - 1) / 2], it[i]); });
+template<class _RandomAccessIterator, class _DifferenceType, class _Compare>
+_RandomAccessIterator is_heap_until_local(_RandomAccessIterator __first, _DifferenceType __begin, _DifferenceType __end, _Compare __comp,
+    /* __is_vector = */ std::true_type) noexcept {
+    return unseq_backend::simd_first(__first, __begin, __end,
+        [&__comp](_RandomAccessIterator __it, _DifferenceType __i) {return __comp(__it[(__i - 1) / 2], __it[__i]); });
 }
 
-template<class RandomAccessIterator, class Compare, class IsVector>
-RandomAccessIterator pattern_is_heap_until(RandomAccessIterator first, RandomAccessIterator last, Compare comp,
-    IsVector vec, /* is_parallel = */ std::true_type) noexcept {
-    if (last - first < 2)
-        return last;
+template<class _RandomAccessIterator, class _Compare, class _IsVector>
+_RandomAccessIterator pattern_is_heap_until(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp,
+    _IsVector __is_vector, /* is_parallel = */ std::true_type) noexcept {
+    if (__last - __first < 2)
+        return __last;
 
-    return except_handler([=]() {
-        return internal::parallel_find(first, last, [first, last, comp, vec](RandomAccessIterator i, RandomAccessIterator j) {
-            return is_heap_until_local(first, i - first, j - first, comp, vec);
+    return internal::except_handler([=]() {
+        return internal::parallel_find(__first, __last, [__first, __last, __comp, __is_vector](_RandomAccessIterator __i, _RandomAccessIterator __j) {
+            return internal::is_heap_until_local(__first, __i - __first, __j - __first, __comp, __is_vector);
         },
-        std::less<typename std::iterator_traits<RandomAccessIterator>::difference_type>(), /*is_first=*/true);
-
+        std::less<typename std::iterator_traits<_RandomAccessIterator>::difference_type>(), /*is___first=*/true);
     });
 
 }
@@ -1799,36 +1813,36 @@ RandomAccessIterator pattern_is_heap_until(RandomAccessIterator first, RandomAcc
 // min_element
 //------------------------------------------------------------------------
 
-template <typename ForwardIterator, typename Compare>
-ForwardIterator brick_min_element(ForwardIterator first, ForwardIterator last, Compare comp, /* is_vector = */ std::false_type) noexcept {
-    return std::min_element(first, last, comp);
+template <typename _ForwardIterator, typename _Compare>
+_ForwardIterator brick_min_element(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp, /* __is_vector = */ std::false_type) noexcept {
+    return std::min_element(__first, __last, __comp);
 }
 
-template <typename ForwardIterator, typename Compare>
-ForwardIterator brick_min_element(ForwardIterator first, ForwardIterator last, Compare comp, /* is_vector = */ std::true_type) noexcept {
+template <typename _ForwardIterator, typename _Compare>
+_ForwardIterator brick_min_element(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp, /* __is_vector = */ std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
-    return std::min_element(first, last, comp);
+    return std::min_element(__first, __last, __comp);
 }
 
-template <typename ForwardIterator, typename Compare, typename IsVector>
-ForwardIterator pattern_min_element(ForwardIterator first, ForwardIterator last, Compare comp, IsVector is_vector, /* is_parallel = */ std::false_type) noexcept {
-    return brick_min_element(first, last, comp, is_vector);
+template <typename _ForwardIterator, typename _Compare, typename _IsVector>
+_ForwardIterator pattern_min_element(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp, _IsVector __is_vector, /* is_parallel = */ std::false_type) noexcept {
+    return internal::brick_min_element(__first, __last, __comp, __is_vector);
 }
 
-template <typename ForwardIterator, typename Compare, typename IsVector>
-ForwardIterator pattern_min_element(ForwardIterator first, ForwardIterator last, Compare comp, IsVector is_vector, /* is_parallel = */ std::true_type) noexcept {
-    if(first == last)
-        return last;
+template <typename _RandomAccessIterator, typename _Compare, typename _IsVector>
+_RandomAccessIterator pattern_min_element(_RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp, _IsVector __is_vector, /* is_parallel = */ std::true_type) noexcept {
+    if(__first == __last)
+        return __last;
 
-    return except_handler([=]() {
+    return internal::except_handler([=]() {
         return par_backend::parallel_reduce(
-            first + 1, last, first,
-            [=](ForwardIterator begin, ForwardIterator end, ForwardIterator init) -> ForwardIterator {
-                const ForwardIterator subresult = brick_min_element(begin, end, comp, is_vector);
-                return cmp_iterators_by_values(init, subresult, comp);
+            __first + 1, __last, __first,
+            [=](_RandomAccessIterator __begin, _RandomAccessIterator __end, _RandomAccessIterator __init) -> _RandomAccessIterator {
+                const _RandomAccessIterator subresult = brick_min_element(__begin, __end, __comp, __is_vector);
+                return internal::cmp_iterators_by_values(__init, subresult, __comp);
             },
-            [=](ForwardIterator it1, ForwardIterator it2) -> ForwardIterator {
-                return cmp_iterators_by_values(it1, it2, comp);
+            [=](_RandomAccessIterator __it1, _RandomAccessIterator __it2) -> _RandomAccessIterator {
+                return internal::cmp_iterators_by_values(__it1, __it2, __comp);
             }
         );
     });
@@ -1838,38 +1852,41 @@ ForwardIterator pattern_min_element(ForwardIterator first, ForwardIterator last,
 // minmax_element
 //------------------------------------------------------------------------
 
-template <typename ForwardIterator, typename Compare>
-std::pair<ForwardIterator, ForwardIterator> brick_minmax_element(ForwardIterator first, ForwardIterator last, Compare comp, /* is_vector = */ std::false_type) noexcept {
-    return std::minmax_element(first, last, comp);
+template <typename _ForwardIterator, typename _Compare>
+std::pair<_ForwardIterator, _ForwardIterator> brick_minmax_element(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp, /* __is_vector = */ std::false_type) noexcept {
+    return std::minmax_element(__first, __last, __comp);
 }
 
-template <typename ForwardIterator, typename Compare>
-std::pair<ForwardIterator, ForwardIterator> brick_minmax_element(ForwardIterator first, ForwardIterator last, Compare comp, /* is_vector = */ std::true_type) noexcept {
+template <typename _ForwardIterator, typename _Compare>
+std::pair<_ForwardIterator, _ForwardIterator> brick_minmax_element(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp, /* __is_vector = */ std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
-    return std::minmax_element(first, last, comp);
+    return std::minmax_element(__first, __last, __comp);
 }
 
-template <typename ForwardIterator, typename Compare, typename IsVector>
-std::pair<ForwardIterator, ForwardIterator> pattern_minmax_element(ForwardIterator first, ForwardIterator last, Compare comp, IsVector is_vector, /* is_parallel = */ std::false_type) noexcept {
-    return brick_minmax_element(first, last, comp, is_vector);
+template <typename _ForwardIterator, typename _Compare, typename _IsVector>
+std::pair<_ForwardIterator, _ForwardIterator> pattern_minmax_element(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp, _IsVector __is_vector, /* is_parallel = */ std::false_type) noexcept {
+    return internal::brick_minmax_element(__first, __last, __comp, __is_vector);
 }
 
-template <typename ForwardIterator, typename Compare, typename IsVector>
-std::pair<ForwardIterator, ForwardIterator> pattern_minmax_element(ForwardIterator first, ForwardIterator last, Compare comp, IsVector is_vector, /* is_parallel = */ std::true_type) noexcept {
-    if(first == last)
-        return std::make_pair(first, first);
+template <typename _ForwardIterator, typename _Compare, typename _IsVector>
+std::pair<_ForwardIterator, _ForwardIterator> pattern_minmax_element(_ForwardIterator __first, _ForwardIterator __last, _Compare __comp, _IsVector __is_vector, /* is_parallel = */ std::true_type) noexcept {
+    if(__first == __last)
+        return std::make_pair(__first, __first);
 
-    return except_handler([=]() {
-        typedef std::pair<ForwardIterator, ForwardIterator> result_t;
+    return internal::except_handler([=]() {
+        typedef std::pair<_ForwardIterator, _ForwardIterator> _result_t;
 
         return par_backend::parallel_reduce(
-            first + 1, last, std::make_pair(first, first),
-            [=](ForwardIterator begin, ForwardIterator end, result_t init) -> result_t {
-                const result_t subresult = brick_minmax_element(begin, end, comp, is_vector);
-                return std::make_pair(cmp_iterators_by_values(subresult.first, init.first, comp), cmp_iterators_by_values(init.second, subresult.second, not_pred<Compare>(comp)));
+            __first + 1, __last, std::make_pair(__first, __first),
+            [=](_ForwardIterator __begin, _ForwardIterator __end, _result_t __init) -> _result_t {
+                const _result_t __subresult = brick_minmax_element(__begin, __end, __comp, __is_vector);
+                return std::make_pair(internal::cmp_iterators_by_values(__subresult.first, __init.first, __comp),
+                                      internal::cmp_iterators_by_values(__init.second, __subresult.second,
+                                                                        internal::not_pred<_Compare>(__comp)));
             },
-            [=](result_t p1, result_t p2) -> result_t {
-                return std::make_pair(cmp_iterators_by_values(p1.first, p2.first, comp), cmp_iterators_by_values(p2.second, p1.second, not_pred<Compare>(comp)));
+            [=](_result_t __p1, _result_t __p2) -> _result_t {
+                return std::make_pair(internal::cmp_iterators_by_values(__p1.first, __p2.first, __comp),
+                                      internal::cmp_iterators_by_values(__p2.second, __p1.second, internal::not_pred<_Compare>(__comp)));
             }
         );
     });
@@ -1878,41 +1895,42 @@ std::pair<ForwardIterator, ForwardIterator> pattern_minmax_element(ForwardIterat
 //------------------------------------------------------------------------
 // mismatch
 //------------------------------------------------------------------------
-template<class InputIterator1, class InputIterator2, class BinaryPredicate>
-std::pair<InputIterator1, InputIterator2> mismatch_serial(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, BinaryPredicate pred) {
+template<class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+std::pair<_ForwardIterator1, _ForwardIterator2> mismatch_serial(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2, _BinaryPredicate __pred) {
 #if __PSTL_CPP14_2RANGE_MISMATCH_EQUAL_PRESENT
-    return std::mismatch(first1, last1, first2, last2, pred);
+    return std::mismatch(__first1, __last1, __first2, __last2, __pred);
 #else
-    for (; first1 != last1 && first2 != last2 && pred(*first1, *first2); ++first1,++first2){ }
-    return std::make_pair(first1, first2);
+    for (; __first1 != __last1 && __first2 != __last2 && __pred(*__first1, *__first2); ++__first1,++__first2){ }
+    return std::make_pair(__first1, __first2);
 #endif
 }
 
-template <class InputIterator1, class InputIterator2, class Predicate>
-std::pair<InputIterator1, InputIterator2> brick_mismatch(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, Predicate pred, /* is_vector = */ std::false_type) noexcept {
-    return mismatch_serial(first1, last1, first2, last2, pred);
+template <class _ForwardIterator1, class _ForwardIterator2, class _Predicate>
+std::pair<_ForwardIterator1, _ForwardIterator2> brick_mismatch(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2, _Predicate __pred, /* __is_vector = */ std::false_type) noexcept {
+    return internal::mismatch_serial(__first1, __last1, __first2, __last2, __pred);
 }
 
-template <class InputIterator1, class InputIterator2, class Predicate>
-std::pair<InputIterator1, InputIterator2> brick_mismatch(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, Predicate pred, /* is_vector = */ std::true_type) noexcept {
-    auto n = std::min(last1 - first1, last2 - first2);
-    return unseq_backend::simd_first(first1, n, first2, not_pred<Predicate>(pred));
+template <class _ForwardIterator1, class _ForwardIterator2, class _Predicate>
+std::pair<_ForwardIterator1, _ForwardIterator2> brick_mismatch(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2, _Predicate __pred, /* __is_vector = */ std::true_type) noexcept {
+    auto n = std::min(__last1 - __first1, __last2 - __first2);
+    return unseq_backend::simd_first(__first1, n, __first2, not_pred<_Predicate>(__pred));
 }
 
-template <class InputIterator1, class InputIterator2, class Predicate, class IsVector>
-std::pair<InputIterator1, InputIterator2> pattern_mismatch(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, Predicate pred, IsVector is_vector, /* is_parallel = */ std::false_type) noexcept {
-    return brick_mismatch(first1, last1, first2, last2, pred, is_vector);
+template <class _ForwardIterator1, class _ForwardIterator2, class _Predicate, class _IsVector>
+std::pair<_ForwardIterator1, _ForwardIterator2> pattern_mismatch(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2, _Predicate __pred, _IsVector __is_vector, /* is_parallel = */ std::false_type) noexcept {
+    return internal::brick_mismatch(__first1, __last1, __first2, __last2, __pred, __is_vector);
 }
 
-template <class InputIterator1, class InputIterator2, class Predicate, class IsVector>
-std::pair<InputIterator1, InputIterator2> pattern_mismatch(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, Predicate pred, IsVector is_vector, /* is_parallel = */ std::true_type) noexcept {
-    return except_handler([=]() {
-        auto n = std::min(last1 - first1, last2 - first2);
-        auto result = internal::parallel_find(first1, first1 + n, [first1, first2, pred, is_vector](InputIterator1 i, InputIterator1 j) {
-            return brick_mismatch(i, j, first2 + (i - first1), first2 + (j - first1), pred, is_vector).first;
+template <class _RandomAccessIterator1, class _RandomAccessIterator2, class _Predicate, class _IsVector>
+std::pair<_RandomAccessIterator1, _RandomAccessIterator2> pattern_mismatch(_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2, _RandomAccessIterator2 __last2, _Predicate __pred, _IsVector __is_vector, /* is_parallel = */ std::true_type) noexcept {
+    return internal::except_handler([=]() {
+        auto n = std::min(__last1 - __first1, __last2 - __first2);
+        auto result = internal::parallel_find(__first1, __first1 + n,
+                                              [__first1, __first2, __pred, __is_vector](_RandomAccessIterator1 __i, _RandomAccessIterator1 __j) {
+           return internal::brick_mismatch(__i, __j, __first2 + (__i - __first1), __first2 + (__j - __first1), __pred, __is_vector).first;
         },
-        std::less<typename std::iterator_traits<InputIterator1>::difference_type>(), /*is_first=*/true);
-        return std::make_pair(result, first2 + (result - first1));
+        std::less<typename std::iterator_traits<_RandomAccessIterator1>::difference_type>(), /*is___first=*/true);
+        return std::make_pair(result, __first2 + (result - __first1));
     });
 }
 
@@ -1920,29 +1938,29 @@ std::pair<InputIterator1, InputIterator2> pattern_mismatch(InputIterator1 first1
 // lexicographical_compare
 //------------------------------------------------------------------------
 
-template<class InputIterator1, class InputIterator2, class Compare>
-bool brick_lexicographical_compare(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, Compare comp, /* is_vector = */ std::false_type) noexcept {
-    return std::lexicographical_compare(first1, last1, first2, last2, comp);
+template<class _ForwardIterator1, class _ForwardIterator2, class _Compare>
+bool brick_lexicographical_compare(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2, _Compare __comp, /* __is_vector = */ std::false_type) noexcept {
+    return std::lexicographical_compare(__first1, __last1, __first2, __last2, __comp);
 }
 
-template<class InputIterator1, class InputIterator2, class Compare>
-bool brick_lexicographical_compare(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, Compare comp, /* is_vector = */ std::true_type) noexcept {
+template<class _ForwardIterator1, class _ForwardIterator2, class _Compare>
+bool brick_lexicographical_compare(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2, _Compare __comp, /* __is_vector = */ std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Vectorized algorithm unimplemented, redirected to serial");
-    return std::lexicographical_compare(first1, last1, first2, last2, comp);
+    return std::lexicographical_compare(__first1, __last1, __first2, __last2, __comp);
 }
 
-template<class InputIterator1, class InputIterator2, class Compare, class IsVector>
-bool pattern_lexicographical_compare(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, Compare comp, IsVector is_vector, /* is_parallel = */ std::false_type) noexcept {
-    return brick_lexicographical_compare(first1, last1, first2, last2, comp, is_vector);
+template<class _ForwardIterator1, class _ForwardIterator2, class _Compare, class _IsVector>
+bool pattern_lexicographical_compare(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2, _Compare __comp, _IsVector __is_vector, /* is_parallel = */ std::false_type) noexcept {
+    return internal::brick_lexicographical_compare(__first1, __last1, __first2, __last2, __comp, __is_vector);
 }
 
-template<class InputIterator1, class InputIterator2, class Compare, class IsVector>
-bool pattern_lexicographical_compare(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, InputIterator2 last2, Compare comp, IsVector is_vector, /* is_parallel = */ std::true_type) noexcept {
+template<class _ForwardIterator1, class _ForwardIterator2, class _Compare, class _IsVector>
+bool pattern_lexicographical_compare(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2, _Compare __comp, _IsVector __is_vector, /* is_parallel = */ std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Parallel algorithm unimplemented, redirected to serial");
-    return brick_lexicographical_compare(first1, last1, first2, last2, comp, is_vector);
+    return internal::brick_lexicographical_compare(__first1, __last1, __first2, __last2, __comp, __is_vector);
 }
 
 } // namespace internal
-} // namespace pstl
+} // namespace __pstl
 
 #endif /* __PSTL_algorithm_impl_H */

--- a/include/pstl/internal/execution_defs.h
+++ b/include/pstl/internal/execution_defs.h
@@ -24,7 +24,7 @@
 
 #include <type_traits>
 
-namespace pstl {
+namespace __pstl {
 namespace execution {
 inline namespace v1 {
 
@@ -93,7 +93,7 @@ template<class T> constexpr bool is_execution_policy_v = is_execution_policy<T>:
 
 namespace internal {
     template<class ExecPolicy, class T> using enable_if_execution_policy = typename std::enable_if<
-      pstl::execution::is_execution_policy<typename std::decay<ExecPolicy>::type>::value, T>::type;
+      __pstl::execution::is_execution_policy<typename std::decay<ExecPolicy>::type>::value, T>::type;
 } // namespace internal
-} //namespace pstl
+} //namespace __pstl
 #endif /* __PSTL_execution_policy_defs_H */

--- a/include/pstl/internal/execution_impl.h
+++ b/include/pstl/internal/execution_impl.h
@@ -26,36 +26,36 @@
 
 #include "execution_defs.h"
 
-namespace pstl {
+namespace __pstl {
 namespace internal {
-using namespace pstl::execution;
+using namespace __pstl::execution;
 
 /* predicate */
 
-template<typename T>
-    std::false_type lazy_and( T, std::false_type ) { return std::false_type{}; };
+template<typename _Tp>
+    std::false_type lazy_and( _Tp, std::false_type ) { return std::false_type{}; };
 
-template<typename T>
-    inline T lazy_and( T a, std::true_type ) { return a; }
+template<typename _Tp>
+    inline _Tp lazy_and( _Tp __a, std::true_type ) { return __a; }
 
-template<typename T>
-    std::true_type lazy_or( T, std::true_type ) { return std::true_type{}; };
+template<typename _Tp>
+    std::true_type lazy_or( _Tp, std::true_type ) { return std::true_type{}; };
 
-template<typename T>
-    inline T lazy_or( T a, std::false_type ) { return a; }
+template<typename _Tp>
+    inline _Tp lazy_or( _Tp __a, std::false_type ) { return __a; }
 
 /* iterator */
-template<typename iterator_type, typename... other_iterator_types>
+template<typename _IteratorType, typename... _OtherIteratorTypes>
 struct is_random_access_iterator {
     static constexpr bool value =
-        is_random_access_iterator<iterator_type>::value &&
-        is_random_access_iterator<other_iterator_types...>::value;
+        is_random_access_iterator<_IteratorType>::value &&
+        is_random_access_iterator<_OtherIteratorTypes...>::value;
     typedef std::integral_constant<bool, value> type;
 };
 
-template<typename iterator_type>
-struct is_random_access_iterator<iterator_type>
-    : std::is_same<typename std::iterator_traits<iterator_type>::iterator_category,
+template<typename _IteratorType>
+struct is_random_access_iterator<_IteratorType>
+    : std::is_same<typename std::iterator_traits<_IteratorType>::iterator_category,
                    std::random_access_iterator_tag> {
 };
 
@@ -101,47 +101,47 @@ template<class ExecPolicy, class T> using enable_if_execution_policy = typename 
     is_execution_policy<typename std::decay<ExecPolicy>::type>::value, T>::type;
 */
 
-template<typename ExecutionPolicy> using collector_t =
-    typename policy_traits<typename std::decay<ExecutionPolicy>::type>::collector_type;
+template<typename _ExecutionPolicy> using collector_t =
+    typename policy_traits<typename std::decay<_ExecutionPolicy>::type>::collector_type;
 
-template<typename ExecutionPolicy> using allow_vector =
-    typename internal::policy_traits<typename std::decay<ExecutionPolicy>::type>::allow_vector;
+template<typename _ExecutionPolicy> using allow_vector =
+    typename internal::policy_traits<typename std::decay<_ExecutionPolicy>::type>::allow_vector;
 
-template<typename ExecutionPolicy> using allow_unsequenced =
-    typename internal::policy_traits<typename std::decay<ExecutionPolicy>::type>::allow_unsequenced;
+template<typename _ExecutionPolicy> using allow_unsequenced =
+    typename internal::policy_traits<typename std::decay<_ExecutionPolicy>::type>::allow_unsequenced;
 
-template<typename ExecutionPolicy> using allow_parallel =
-    typename internal::policy_traits<typename std::decay<ExecutionPolicy>::type>::allow_parallel;
+template<typename _ExecutionPolicy> using allow_parallel =
+    typename internal::policy_traits<typename std::decay<_ExecutionPolicy>::type>::allow_parallel;
 
 
-template<typename ExecutionPolicy, typename... iterator_types>
-auto is_vectorization_preferred(ExecutionPolicy&& exec) ->
-decltype(lazy_and( exec.__allow_vector(), typename is_random_access_iterator<iterator_types...>::type()))
+template<typename _ExecutionPolicy, typename... _IteratorTypes>
+auto is_vectorization_preferred(_ExecutionPolicy&& __exec) ->
+decltype(lazy_and( __exec.__allow_vector(), typename is_random_access_iterator<_IteratorTypes...>::type()))
 {
-    return lazy_and( exec.__allow_vector(), typename is_random_access_iterator<iterator_types...>::type() );
+    return internal::lazy_and( __exec.__allow_vector(), typename is_random_access_iterator<_IteratorTypes...>::type() );
 }
 
-template<typename ExecutionPolicy, typename... iterator_types>
-auto is_parallelization_preferred(ExecutionPolicy&& exec) ->
-decltype(lazy_and( exec.__allow_parallel(), typename is_random_access_iterator<iterator_types...>::type()))
+template<typename _ExecutionPolicy, typename... _IteratorTypes>
+auto is_parallelization_preferred(_ExecutionPolicy&& __exec) ->
+decltype(lazy_and( __exec.__allow_parallel(), typename is_random_access_iterator<_IteratorTypes...>::type()))
 {
-    return lazy_and( exec.__allow_parallel(), typename is_random_access_iterator<iterator_types...>::type() );
+    return internal::lazy_and( __exec.__allow_parallel(), typename is_random_access_iterator<_IteratorTypes...>::type() );
 }
 
-template<typename policy, typename... iterator_types>
+template<typename policy, typename... _IteratorTypes>
 struct prefer_unsequenced_tag {
     static constexpr bool value =
-        allow_unsequenced<policy>::value && is_random_access_iterator<iterator_types...>::value;
+        allow_unsequenced<policy>::value && is_random_access_iterator<_IteratorTypes...>::value;
     typedef std::integral_constant<bool, value> type;
 };
 
-template<typename policy, typename... iterator_types>
+template<typename policy, typename... _IteratorTypes>
 struct prefer_parallel_tag {
     static constexpr bool value =
-        allow_parallel<policy>::value && is_random_access_iterator<iterator_types...>::value;
+        allow_parallel<policy>::value && is_random_access_iterator<_IteratorTypes...>::value;
     typedef std::integral_constant<bool, value> type;
 };
 } // namespace internal
-} // namespace pstl
+} // namespace __pstl
 
 #endif /* __PSTL_execution_policy_impl_H */

--- a/include/pstl/internal/glue_algorithm_defs.h
+++ b/include/pstl/internal/glue_algorithm_defs.h
@@ -137,9 +137,9 @@ template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator
 __pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
 copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result);
 
-template<class _ExecutionPolicy, class _ForwardIterator1, class _size, class _ForwardIterator2>
+template<class _ExecutionPolicy, class _ForwardIterator1, class _Size, class _ForwardIterator2>
 __pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
-copy_n(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _size __n, _ForwardIterator2 __result);
+copy_n(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _Size __n, _ForwardIterator2 __result);
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Predicate>
 __pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
@@ -166,23 +166,23 @@ transform(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterato
 
 // [alg.replace]
 
-template<class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate, class _tp>
+template<class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate, class _Tp>
 __pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
-replace_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred, const _tp& __new_value);
+replace_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred, const _Tp& __new_value);
 
-template<class _ExecutionPolicy, class _ForwardIterator, class _tp>
+template<class _ExecutionPolicy, class _ForwardIterator, class _Tp>
 __pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
-replace(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _tp& __old_value, const _tp& __new_value);
+replace(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __old_value, const _Tp& __new_value);
 
-template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _UnaryPredicate, class _tp>
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _UnaryPredicate, class _Tp>
 __pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
 replace_copy_if(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, _UnaryPredicate __pred,
-                const _tp& __new_value);
+                const _Tp& __new_value);
 
-template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _tp>
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp>
 __pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
-replace_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, const _tp& __old_value,
-             const _tp& __new_value);
+replace_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, const _Tp& __old_value,
+             const _Tp& __new_value);
 
 // [alg.fill]
 

--- a/include/pstl/internal/glue_algorithm_defs.h
+++ b/include/pstl/internal/glue_algorithm_defs.h
@@ -30,494 +30,494 @@ namespace std {
 
 // [alg.any_of]
 
-template<class ExecutionPolicy, class ForwardIterator, class Predicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-any_of(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, Predicate pred);
+template<class _ExecutionPolicy, class _ForwardIterator, class ___Predicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+any_of(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, ___Predicate __pred);
 
 // [alg.all_of]
 
-template<class ExecutionPolicy, class ForwardIterator, class Pred>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-all_of(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, Pred pred);
+template<class _ExecutionPolicy, class _ForwardIterator, class ___Predicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+all_of(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, ___Predicate __pred);
 
 // [alg.none_of]
 
-template<class ExecutionPolicy, class ForwardIterator, class Predicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-none_of(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, Predicate pred);
+template<class _ExecutionPolicy, class _ForwardIterator, class ___Predicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+none_of(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, ___Predicate __pred);
 
 // [alg.foreach]
 
-template<class ExecutionPolicy, class ForwardIterator, class Function>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-for_each(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, Function f);
+template<class _ExecutionPolicy, class _ForwardIterator, class _Function>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+for_each(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Function __f);
 
-template<class ExecutionPolicy, class ForwardIterator, class Size, class Function>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-for_each_n(ExecutionPolicy&& exec, ForwardIterator first, Size n, Function f);
+template<class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Function>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+for_each_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n, _Function __f);
 
 // [alg.find]
 
-template<class ExecutionPolicy, class ForwardIterator, class Predicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-find_if(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, Predicate pred);
+template<class _ExecutionPolicy, class _ForwardIterator, class ___Predicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+find_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, ___Predicate __pred);
 
-template<class ExecutionPolicy, class ForwardIterator, class Predicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-find_if_not(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, Predicate pred);
+template<class _ExecutionPolicy, class _ForwardIterator, class ___Predicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+find_if_not(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, ___Predicate __pred);
 
-template<class ExecutionPolicy, class ForwardIterator, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-find(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, const T& value);
+template<class _ExecutionPolicy, class _ForwardIterator, class _Tp>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+find(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value);
 
 // [alg.find.end]
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class BinaryPredicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator1>
-find_end(ExecutionPolicy &&exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 s_first, ForwardIterator2 s_last,
-         BinaryPredicate pred);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+find_end(_ExecutionPolicy &&__exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last,
+         _BinaryPredicate __pred);
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator1>
-find_end(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 s_first, ForwardIterator2 s_last);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+find_end(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last);
 
 // [alg.find_first_of]
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class BinaryPredicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator1>
-find_first_of(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 s_first, ForwardIterator2 s_last,
-              BinaryPredicate pred);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+find_first_of(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last,
+              _BinaryPredicate __pred);
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator1>
-find_first_of(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 s_first, ForwardIterator2 s_last);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+find_first_of(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last);
 
 // [alg.adjacent_find]
 
-template< class ExecutionPolicy, class ForwardIterator >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-adjacent_find(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last);
+template< class _ExecutionPolicy, class _ForwardIterator >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+adjacent_find(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last);
 
-template< class ExecutionPolicy, class ForwardIterator, class BinaryPredicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-adjacent_find(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, BinaryPredicate pred);
+template< class _ExecutionPolicy, class _ForwardIterator, class _BinaryPredicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+adjacent_find(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _BinaryPredicate __pred);
 
 // [alg.count]
 
-template<class ExecutionPolicy, class ForwardIterator, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,typename iterator_traits<ForwardIterator>::difference_type>
-count(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, const T& value);
+template<class _ExecutionPolicy, class _ForwardIterator, class _Tp>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy,typename iterator_traits<_ForwardIterator>::difference_type>
+count(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value);
 
-template<class ExecutionPolicy, class ForwardIterator, class Predicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,typename iterator_traits<ForwardIterator>::difference_type>
-count_if(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, Predicate pred);
+template<class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy,typename iterator_traits<_ForwardIterator>::difference_type>
+count_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred);
 
 // [alg.search]
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class BinaryPredicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator1>
-search(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 s_first, ForwardIterator2 s_last,
-       BinaryPredicate pred);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+search(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last,
+       _BinaryPredicate __pred);
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator1>
-search(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 s_first, ForwardIterator2 s_last);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+search(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last);
 
-template<class ExecutionPolicy, class ForwardIterator, class Size, class T, class BinaryPredicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-search_n(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, Size count, const T& value, BinaryPredicate pred);
+template<class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp, class _BinaryPredicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+search_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Size __count, const _Tp& __value, _BinaryPredicate __pred);
 
-template<class ExecutionPolicy, class ForwardIterator, class Size, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-search_n(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, Size count, const T& value);
+template<class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+search_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Size __count, const _Tp& __value);
 
 // [alg.copy]
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
-copy(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result);
+template<class _executionpolicy, class _forwarditerator1, class _forwarditerator2>
+pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator2>
+copy(_executionpolicy&& __exec, _forwarditerator1 __first, _forwarditerator1 __last, _forwarditerator2 __result);
 
-template<class ExecutionPolicy, class ForwardIterator1, class Size, class ForwardIterator2>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
-copy_n(ExecutionPolicy&& exec, ForwardIterator1 first, Size n, ForwardIterator2 result);
+template<class _executionpolicy, class _forwarditerator1, class _size, class _forwarditerator2>
+pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator2>
+copy_n(_executionpolicy&& __exec, _forwarditerator1 __first, _size __n, _forwarditerator2 __result);
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class Predicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
-copy_if(ExecutionPolicy&& exec,
-        ForwardIterator1 first, ForwardIterator1 last,
-        ForwardIterator2 result, Predicate pred);
+template<class _executionpolicy, class _forwarditerator1, class _forwarditerator2, class _predicate>
+pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator2>
+copy_if(_executionpolicy&& __exec,
+        _forwarditerator1 __first, _forwarditerator1 __last,
+        _forwarditerator2 result, _predicate __pred);
 
 // [alg.swap]
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator2>
-swap_ranges(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2);
+template<class _executionpolicy, class _forwarditerator1, class _forwarditerator2>
+pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator2>
+swap_ranges(_executionpolicy&& __exec, _forwarditerator1 __first1, _forwarditerator1 __last1, _forwarditerator2 __first2);
 
 // [alg.transform]
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class UnaryOperation>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
-transform( ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, UnaryOperation op );
+template<class _executionpolicy, class _forwarditerator1, class _forwarditerator2, class _unaryoperation>
+pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator2>
+transform( _executionpolicy&& __exec, _forwarditerator1 __first, _forwarditerator1 __last, _forwarditerator2 __result, _unaryoperation __op );
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class ForwardIterator, class BinaryOperation>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator>
-transform(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator result,
-          BinaryOperation op);
+template<class _executionpolicy, class _forwarditerator1, class _forwarditerator2, class _forwarditerator, class _binaryoperation>
+pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator>
+transform(_executionpolicy&& __exec, _forwarditerator1 __first1, _forwarditerator1 __last1, _forwarditerator2 __first2, _forwarditerator __result,
+          _binaryoperation __op);
 
 // [alg.replace]
 
-template<class ExecutionPolicy, class ForwardIterator, class UnaryPredicate, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-replace_if(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, UnaryPredicate pred, const T& new_value);
+template<class _executionpolicy, class _forwarditerator, class _unarypredicate, class _tp>
+pstl::internal::enable_if_execution_policy<_executionpolicy, void>
+replace_if(_executionpolicy&& __exec, _forwarditerator __first, _forwarditerator __last, _unarypredicate __pred, const _tp& __new_value);
 
-template<class ExecutionPolicy, class ForwardIterator, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-replace(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, const T& old_value, const T& new_value);
+template<class _executionpolicy, class _forwarditerator, class _tp>
+pstl::internal::enable_if_execution_policy<_executionpolicy, void>
+replace(_executionpolicy&& __exec, _forwarditerator __first, _forwarditerator __last, const _tp& __old_value, const _tp& __new_value);
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class UnaryPredicate, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator2>
-replace_copy_if(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, UnaryPredicate pred,
-                const T& new_value);
+template<class _executionpolicy, class _forwarditerator1, class _forwarditerator2, class _unarypredicate, class _tp>
+pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator2>
+replace_copy_if(_executionpolicy&& __exec, _forwarditerator1 __first, _forwarditerator1 __last, _forwarditerator2 __result, _unarypredicate __pred,
+                const _tp& __new_value);
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator2>
-replace_copy(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, const T& old_value,
-             const T& new_value);
+template<class _executionpolicy, class _forwarditerator1, class _forwarditerator2, class _tp>
+pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator2>
+replace_copy(_executionpolicy&& __exec, _forwarditerator1 __first, _forwarditerator1 __last, _forwarditerator2 __result, const _tp& __old_value,
+             const _tp& __new_value);
 
 // [alg.fill]
 
-template <class ExecutionPolicy, class ForwardIterator, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-fill( ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, const T& value );
+template <class _executionpolicy, class _forwarditerator, class _tp>
+pstl::internal::enable_if_execution_policy<_executionpolicy, void>
+fill( _executionpolicy&& __exec, _forwarditerator __first, _forwarditerator __last, const _tp& __value );
 
-template< class ExecutionPolicy, class ForwardIterator, class Size, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-fill_n( ExecutionPolicy&& exec, ForwardIterator first, Size count, const T& value );
+template< class _executionpolicy, class _forwarditerator, class _size, class _tp>
+pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator>
+fill_n( _executionpolicy&& __exec, _forwarditerator __first, _size __count, const _tp& __value );
 
 // [alg.generate]
-template< class ExecutionPolicy, class ForwardIterator, class Generator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-generate( ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, Generator g );
+template< class _executionpolicy, class _forwarditerator, class _generator>
+pstl::internal::enable_if_execution_policy<_executionpolicy, void>
+generate( _executionpolicy&& __exec, _forwarditerator __first, _forwarditerator __last, _generator __g );
 
-template< class ExecutionPolicy, class ForwardIterator, class Size, class Generator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-generate_n( ExecutionPolicy&& exec, ForwardIterator first, Size count, Generator g );
+template< class _executionpolicy, class _forwarditerator, class _size, class _generator>
+pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator>
+generate_n( _executionpolicy&& __exec, _forwarditerator __first, _size count, _generator __g );
 
 // [alg.remove]
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class Predicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
-remove_copy_if(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, Predicate pred);
+template<class _executionpolicy, class _forwarditerator1, class _forwarditerator2, class _predicate>
+pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator2>
+remove_copy_if(_executionpolicy&& __exec, _forwarditerator1 __first, _forwarditerator1 __last, _forwarditerator2 __result, _predicate __pred);
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
-remove_copy(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, const T& value);
+template<class _executionpolicy, class _forwarditerator1, class _forwarditerator2, class _tp>
+pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator2>
+remove_copy(_executionpolicy&& __exec, _forwarditerator1 __first, _forwarditerator1 __last, _forwarditerator2 __result, const _tp& __value);
 
-template<class ExecutionPolicy, class ForwardIterator, class UnaryPredicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-remove_if(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, UnaryPredicate pred);
+template<class _executionpolicy, class _forwarditerator, class _unarypredicate>
+pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator>
+remove_if(_executionpolicy&& __exec, _forwarditerator __first, _forwarditerator __last, _unarypredicate __pred);
 
-template<class ExecutionPolicy, class ForwardIterator, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-remove(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, const T& value);
+template<class _executionpolicy, class _forwarditerator, class _tp>
+pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator>
+remove(_executionpolicy&& __exec, _forwarditerator __first, _forwarditerator __last, const _tp& __value);
 
 // [alg.unique]
 
-template<class ExecutionPolicy, class ForwardIterator, class BinaryPredicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-unique(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, BinaryPredicate pred);
+template<class _executionpolicy, class _forwarditerator, class _binarypredicate>
+pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator>
+unique(_executionpolicy&& __exec, _forwarditerator __first, _forwarditerator __last, _binarypredicate __pred);
 
-template<class ExecutionPolicy, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-unique(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last);
+template<class _executionpolicy, class _forwarditerator>
+pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator>
+unique(_executionpolicy&& __exec, _forwarditerator __first, _forwarditerator __last);
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class BinaryPredicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
-unique_copy(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, BinaryPredicate pred);
+template<class _executionpolicy, class _forwarditerator1, class _forwarditerator2, class _binarypredicate>
+pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator2>
+unique_copy(_executionpolicy&& __exec, _forwarditerator1 __first, _forwarditerator1 __last, _forwarditerator2 __result, _binarypredicate __pred);
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
-unique_copy(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result);
+template<class _executionpolicy, class _forwarditerator1, class _forwarditerator2>
+pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator2>
+unique_copy(_executionpolicy&& __exec, _forwarditerator1 __first, _forwarditerator1 __last, _forwarditerator2 __result);
 
 // [alg.reverse]
 
-template<class ExecutionPolicy, class BidirectionalIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-reverse(ExecutionPolicy&& exec, BidirectionalIterator first, BidirectionalIterator last);
+template<class _executionpolicy, class _bidirectionaliterator>
+pstl::internal::enable_if_execution_policy<_executionpolicy, void>
+reverse(_executionpolicy&& __exec, _bidirectionaliterator __first, _bidirectionaliterator __last);
 
-template<class ExecutionPolicy, class BidirectionalIterator, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-reverse_copy(ExecutionPolicy&& exec, BidirectionalIterator first, BidirectionalIterator last, ForwardIterator d_first);
+template<class _ExecutionPolicy, class _BidirectionalIterator, class _ForwardIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+reverse_copy(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __last, _ForwardIterator __d_first);
 
 // [alg.rotate]
 
-template<class ExecutionPolicy, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-rotate(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator middle, ForwardIterator last);
+template<class _ExecutionPolicy, class _ForwardIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+rotate(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __middle, _ForwardIterator __last);
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator2>
-rotate_copy(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 middle, ForwardIterator1 last, ForwardIterator2 result);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+rotate_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __middle, _ForwardIterator1 __last, _ForwardIterator2 __result);
 
 // [alg.partitions]
 
-template<class ExecutionPolicy, class ForwardIterator, class UnaryPredicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-is_partitioned(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, UnaryPredicate pred);
+template<class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+is_partitioned(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred);
 
-template<class ExecutionPolicy, class ForwardIterator, class UnaryPredicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-partition(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, UnaryPredicate pred);
+template<class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+partition(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred);
 
-template<class ExecutionPolicy, class BidirectionalIterator, class UnaryPredicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, BidirectionalIterator>
-stable_partition(ExecutionPolicy&& exec, BidirectionalIterator first, BidirectionalIterator last, UnaryPredicate pred);
+template<class _ExecutionPolicy, class _BidirectionalIterator, class _UnaryPredicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _BidirectionalIterator>
+stable_partition(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __last, _UnaryPredicate __pred);
 
-template<class ExecutionPolicy, class ForwardIterator, class ForwardIterator1, class ForwardIterator2, class UnaryPredicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, std::pair<ForwardIterator1, ForwardIterator2>>
-partition_copy(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, ForwardIterator1 out_true, ForwardIterator2 out_false,
-               UnaryPredicate pred);
+template<class _ExecutionPolicy, class _ForwardIterator, class _ForwardIterator1, class _ForwardIterator2, class _UnaryPredicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
+partition_copy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _ForwardIterator1 __out_true, _ForwardIterator2 __out_false,
+               _UnaryPredicate __pred);
 
 // [alg.sort]
 
-template<class ExecutionPolicy, class RandomAccessIterator, class Compare>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-sort(ExecutionPolicy&& exec, RandomAccessIterator first, RandomAccessIterator last, Compare comp);
+template<class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp);
 
-template<class ExecutionPolicy, class RandomAccessIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-sort(ExecutionPolicy&& exec, RandomAccessIterator first, RandomAccessIterator last);
+template<class _ExecutionPolicy, class _RandomAccessIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last);
 
 // [stable.sort]
 
-template<class ExecutionPolicy, class RandomAccessIterator, class Compare>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-stable_sort(ExecutionPolicy&& exec, RandomAccessIterator first, RandomAccessIterator last, Compare comp);
+template<class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+stable_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp);
 
-template<class ExecutionPolicy, class RandomAccessIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-stable_sort(ExecutionPolicy&& exec, RandomAccessIterator first, RandomAccessIterator last);
+template<class _ExecutionPolicy, class _RandomAccessIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+stable_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last);
 
 // [mismatch]
 
-template< class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class BinaryPredicate >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, std::pair<ForwardIterator1, ForwardIterator2>>
-mismatch(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2,
-         BinaryPredicate pred);
+template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
+mismatch(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
+         _BinaryPredicate pred);
 
-template< class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class BinaryPredicate >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, std::pair<ForwardIterator1, ForwardIterator2>>
-mismatch(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, BinaryPredicate pred);
+template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
+mismatch(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _BinaryPredicate __pred);
 
-template< class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2 >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, std::pair<ForwardIterator1, ForwardIterator2>>
-mismatch(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2);
+template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2 >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
+mismatch(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2);
 
-template< class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2 >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, std::pair<ForwardIterator1, ForwardIterator2>>
-mismatch(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2);
+template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2 >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
+mismatch(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2);
 
 // [alg.equal]
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class BinaryPredicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-equal(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, BinaryPredicate p);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+equal(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _BinaryPredicate __p);
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-equal(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+equal(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2);
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class BinaryPredicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-equal(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2, BinaryPredicate p);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+equal(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2, _BinaryPredicate __p);
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-equal(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+equal(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2);
 
 // [alg.move]
-template< class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2 >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator2>
-move(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 d_first);
+template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2 >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+move(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __d_first);
 
 // [partial.sort]
 
-template<class ExecutionPolicy, class RandomAccessIterator, class Compare>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-partial_sort(ExecutionPolicy&& exec, RandomAccessIterator first, RandomAccessIterator middle, RandomAccessIterator last, Compare comp);
+template<class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+partial_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator middle, _RandomAccessIterator __last, _Compare __comp);
 
-template<class ExecutionPolicy, class RandomAccessIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-partial_sort(ExecutionPolicy&& exec, RandomAccessIterator first, RandomAccessIterator middle, RandomAccessIterator last);
+template<class _ExecutionPolicy, class _RandomAccessIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+partial_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator middle, _RandomAccessIterator __last);
 
 // [partial.sort.copy]
 
-template<class ExecutionPolicy, class ForwardIterator, class RandomAccessIterator, class Compare>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, RandomAccessIterator>
-partial_sort_copy(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, RandomAccessIterator d_first, RandomAccessIterator d_last,
-                  Compare comp);
+template<class _ExecutionPolicy, class _ForwardIterator, class _RandomAccessIterator, class _Compare>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator>
+partial_sort_copy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _RandomAccessIterator d_first, _RandomAccessIterator d_last,
+                  _Compare __comp);
 
-template<class ExecutionPolicy, class ForwardIterator, class RandomAccessIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, RandomAccessIterator>
-partial_sort_copy(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, RandomAccessIterator d_first, RandomAccessIterator d_last);
+template<class _ExecutionPolicy, class _ForwardIterator, class _RandomAccessIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator>
+partial_sort_copy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _RandomAccessIterator d_first, _RandomAccessIterator d_last);
 
 // [is.sorted]
-template<class ExecutionPolicy, class ForwardIterator, class Compare>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-is_sorted_until(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, Compare comp);
+template<class _ExecutionPolicy, class _ForwardIterator, class _Compare>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+is_sorted_until(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Compare __comp);
 
-template<class ExecutionPolicy, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-is_sorted_until(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last);
+template<class _ExecutionPolicy, class _ForwardIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+is_sorted_until(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last);
 
-template<class ExecutionPolicy, class ForwardIterator, class Compare>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-is_sorted(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, Compare comp);
+template<class _ExecutionPolicy, class _ForwardIterator, class _Compare>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+is_sorted(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Compare __comp);
 
-template<class ExecutionPolicy, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-is_sorted(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last);
+template<class _ExecutionPolicy, class _ForwardIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+is_sorted(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last);
 
 // [alg.nth.element]
 
-template<class ExecutionPolicy, class RandomAccessIterator, class Compare>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-nth_element(ExecutionPolicy&& exec, RandomAccessIterator first, RandomAccessIterator nth, RandomAccessIterator last, Compare comp);
+template<class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+nth_element(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __nth, _RandomAccessIterator __last, _Compare __comp);
 
-template<class ExecutionPolicy, class RandomAccessIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-nth_element(ExecutionPolicy&& exec, RandomAccessIterator first, RandomAccessIterator nth, RandomAccessIterator last);
+template<class _ExecutionPolicy, class _RandomAccessIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+nth_element(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __nth, _RandomAccessIterator __last);
 
 // [alg.merge]
-template< class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class ForwardIterator, class Compare>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-merge(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2,
-      ForwardIterator d_first, Compare comp);
+template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator, class _Compare>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+merge(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
+      _ForwardIterator d_first, _Compare __comp);
 
-template< class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-merge(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2,
-      ForwardIterator d_first);
+template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+merge(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
+      _ForwardIterator d_first);
 
-template< class ExecutionPolicy, class BidirectionalIterator, class Compare>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-inplace_merge(ExecutionPolicy&& exec, BidirectionalIterator first, BidirectionalIterator middle, BidirectionalIterator last, Compare comp);
+template< class _ExecutionPolicy, class _BidirectionalIterator, class _Compare>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+inplace_merge(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __middle, _BidirectionalIterator __last, _Compare __comp);
 
-template< class ExecutionPolicy, class BidirectionalIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-inplace_merge(ExecutionPolicy&& exec, BidirectionalIterator first, BidirectionalIterator middle, BidirectionalIterator last);
+template< class _ExecutionPolicy, class _BidirectionalIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+inplace_merge(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __middle, _BidirectionalIterator __last);
 
 // [includes]
 
-template< class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class Compare>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-includes(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2, Compare comp);
+template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Compare>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+includes(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2, _Compare __comp);
 
-template< class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-includes(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2);
+template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+includes(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2);
 
 // [set.union]
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class ForwardIterator, class Compare>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-set_union(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2,
-          ForwardIterator result, Compare comp);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator, class _Compare>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+set_union(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
+          _ForwardIterator __result, _Compare __comp);
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-set_union(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2,
-          ForwardIterator2 last2, ForwardIterator result);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+set_union(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+          _ForwardIterator2 __last2, _ForwardIterator __result);
 
 // [set.intersection]
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class ForwardIterator, class Compare>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-set_intersection(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2,
-                 ForwardIterator result, Compare comp);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator, class _Compare>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+set_intersection(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
+                 _ForwardIterator __result, _Compare __comp);
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-set_intersection(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2,
-                 ForwardIterator result);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+set_intersection(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
+                 _ForwardIterator __result);
 
 // [set.difference]
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class ForwardIterator, class Compare>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-set_difference(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2,
-               ForwardIterator result, Compare comp);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator, class _Compare>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+set_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
+               _ForwardIterator __result, _Compare __comp);
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-set_difference(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2,
-               ForwardIterator result);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+set_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
+               _ForwardIterator __result);
 
 // [set.symmetric.difference]
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class ForwardIterator, class Compare>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-set_symmetric_difference(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2,
-                         ForwardIterator result, Compare comp);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator, class _Compare>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+set_symmetric_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
+                         _ForwardIterator result, _Compare __comp);
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-set_symmetric_difference(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2,
-                         ForwardIterator result);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+set_symmetric_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
+                         _ForwardIterator __result);
 
 // [is.heap]
-template< class ExecutionPolicy, class RandomAccessIterator, class Compare >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, RandomAccessIterator>
-is_heap_until(ExecutionPolicy&& exec, RandomAccessIterator first, RandomAccessIterator last, Compare comp);
+template< class _ExecutionPolicy, class _RandomAccessIterator, class _Compare >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator>
+is_heap_until(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp);
 
-template< class ExecutionPolicy, class RandomAccessIterator >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, RandomAccessIterator>
-is_heap_until(ExecutionPolicy&& exec, RandomAccessIterator first, RandomAccessIterator last);
+template< class _ExecutionPolicy, class _RandomAccessIterator >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator>
+is_heap_until(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last);
 
-template< class ExecutionPolicy, class RandomAccessIterator, class Compare >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-is_heap(ExecutionPolicy&& exec, RandomAccessIterator first, RandomAccessIterator last, Compare comp);
+template< class _ExecutionPolicy, class _RandomAccessIterator, class _Compare >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+is_heap(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp);
 
-template< class ExecutionPolicy, class RandomAccessIterator >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-is_heap(ExecutionPolicy&& exec, RandomAccessIterator first, RandomAccessIterator last);
+template< class _ExecutionPolicy, class _RandomAccessIterator >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+is_heap(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last);
 
 // [alg.min.max]
 
-template< class ExecutionPolicy, class ForwardIterator, class Compare >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-min_element(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, Compare comp);
+template< class _ExecutionPolicy, class _ForwardIterator, class _Compare >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+min_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Compare __comp);
 
-template< class ExecutionPolicy, class ForwardIterator >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-min_element(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last);
+template< class _ExecutionPolicy, class _ForwardIterator >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+min_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last);
 
-template< class ExecutionPolicy, class ForwardIterator, class Compare >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-max_element(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, Compare comp);
+template< class _ExecutionPolicy, class _ForwardIterator, class _Compare >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+max_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Compare __comp);
 
-template< class ExecutionPolicy, class ForwardIterator >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-max_element(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last);
+template< class _ExecutionPolicy, class _ForwardIterator >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+max_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last);
 
-template< class ExecutionPolicy, class ForwardIterator, class Compare >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, std::pair<ForwardIterator, ForwardIterator>>
-minmax_element(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, Compare comp);
+template< class _ExecutionPolicy, class _ForwardIterator, class _Compare >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator, _ForwardIterator>>
+minmax_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Compare __comp);
 
-template< class ExecutionPolicy, class ForwardIterator >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, std::pair<ForwardIterator, ForwardIterator>>
-minmax_element(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last);
+template< class _ExecutionPolicy, class _ForwardIterator >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator, _ForwardIterator>>
+minmax_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last);
 
 // [alg.lex.comparison]
 
-template< class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class Compare >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-lexicographical_compare(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2,
-                        Compare comp);
+template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Compare >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+lexicographical_compare(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
+                        _Compare __comp);
 
-template< class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2 >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-lexicographical_compare(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2);
+template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2 >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+lexicographical_compare(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2);
 
 } // namespace std
 #endif /* __PSTL_glue_algorithm_defs_H_ */

--- a/include/pstl/internal/glue_algorithm_defs.h
+++ b/include/pstl/internal/glue_algorithm_defs.h
@@ -133,117 +133,117 @@ search_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator _
 
 // [alg.copy]
 
-template<class _executionpolicy, class _forwarditerator1, class _forwarditerator2>
-__pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator2>
-copy(_executionpolicy&& __exec, _forwarditerator1 __first, _forwarditerator1 __last, _forwarditerator2 __result);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result);
 
-template<class _executionpolicy, class _forwarditerator1, class _size, class _forwarditerator2>
-__pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator2>
-copy_n(_executionpolicy&& __exec, _forwarditerator1 __first, _size __n, _forwarditerator2 __result);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _size, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+copy_n(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _size __n, _ForwardIterator2 __result);
 
-template<class _executionpolicy, class _forwarditerator1, class _forwarditerator2, class _predicate>
-__pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator2>
-copy_if(_executionpolicy&& __exec,
-        _forwarditerator1 __first, _forwarditerator1 __last,
-        _forwarditerator2 result, _predicate __pred);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Predicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+copy_if(_ExecutionPolicy&& __exec,
+        _ForwardIterator1 __first, _ForwardIterator1 __last,
+        _ForwardIterator2 result, _Predicate __pred);
 
 // [alg.swap]
 
-template<class _executionpolicy, class _forwarditerator1, class _forwarditerator2>
-__pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator2>
-swap_ranges(_executionpolicy&& __exec, _forwarditerator1 __first1, _forwarditerator1 __last1, _forwarditerator2 __first2);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+swap_ranges(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2);
 
 // [alg.transform]
 
-template<class _executionpolicy, class _forwarditerator1, class _forwarditerator2, class _unaryoperation>
-__pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator2>
-transform( _executionpolicy&& __exec, _forwarditerator1 __first, _forwarditerator1 __last, _forwarditerator2 __result, _unaryoperation __op );
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _unaryoperation>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+transform( _ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, _unaryoperation __op );
 
-template<class _executionpolicy, class _forwarditerator1, class _forwarditerator2, class _forwarditerator, class _binaryoperation>
-__pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator>
-transform(_executionpolicy&& __exec, _forwarditerator1 __first1, _forwarditerator1 __last1, _forwarditerator2 __first2, _forwarditerator __result,
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator, class _binaryoperation>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator>
+transform(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator __result,
           _binaryoperation __op);
 
 // [alg.replace]
 
-template<class _executionpolicy, class _forwarditerator, class _unarypredicate, class _tp>
-__pstl::internal::enable_if_execution_policy<_executionpolicy, void>
-replace_if(_executionpolicy&& __exec, _forwarditerator __first, _forwarditerator __last, _unarypredicate __pred, const _tp& __new_value);
+template<class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate, class _tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+replace_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred, const _tp& __new_value);
 
-template<class _executionpolicy, class _forwarditerator, class _tp>
-__pstl::internal::enable_if_execution_policy<_executionpolicy, void>
-replace(_executionpolicy&& __exec, _forwarditerator __first, _forwarditerator __last, const _tp& __old_value, const _tp& __new_value);
+template<class _ExecutionPolicy, class _ForwardIterator, class _tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+replace(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _tp& __old_value, const _tp& __new_value);
 
-template<class _executionpolicy, class _forwarditerator1, class _forwarditerator2, class _unarypredicate, class _tp>
-__pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator2>
-replace_copy_if(_executionpolicy&& __exec, _forwarditerator1 __first, _forwarditerator1 __last, _forwarditerator2 __result, _unarypredicate __pred,
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _UnaryPredicate, class _tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+replace_copy_if(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, _UnaryPredicate __pred,
                 const _tp& __new_value);
 
-template<class _executionpolicy, class _forwarditerator1, class _forwarditerator2, class _tp>
-__pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator2>
-replace_copy(_executionpolicy&& __exec, _forwarditerator1 __first, _forwarditerator1 __last, _forwarditerator2 __result, const _tp& __old_value,
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+replace_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, const _tp& __old_value,
              const _tp& __new_value);
 
 // [alg.fill]
 
-template <class _executionpolicy, class _forwarditerator, class _tp>
-__pstl::internal::enable_if_execution_policy<_executionpolicy, void>
-fill( _executionpolicy&& __exec, _forwarditerator __first, _forwarditerator __last, const _tp& __value );
+template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+fill( _ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value );
 
-template< class _executionpolicy, class _forwarditerator, class _size, class _tp>
-__pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator>
-fill_n( _executionpolicy&& __exec, _forwarditerator __first, _size __count, const _tp& __value );
+template< class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+fill_n( _ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __count, const _Tp& __value );
 
 // [alg.generate]
-template< class _executionpolicy, class _forwarditerator, class _generator>
-__pstl::internal::enable_if_execution_policy<_executionpolicy, void>
-generate( _executionpolicy&& __exec, _forwarditerator __first, _forwarditerator __last, _generator __g );
+template< class _ExecutionPolicy, class _ForwardIterator, class _Generator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+generate( _ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Generator __g );
 
-template< class _executionpolicy, class _forwarditerator, class _size, class _generator>
-__pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator>
-generate_n( _executionpolicy&& __exec, _forwarditerator __first, _size count, _generator __g );
+template< class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Generator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+generate_n( _ExecutionPolicy&& __exec, _ForwardIterator __first, _Size count, _Generator __g );
 
 // [alg.remove]
 
-template<class _executionpolicy, class _forwarditerator1, class _forwarditerator2, class _predicate>
-__pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator2>
-remove_copy_if(_executionpolicy&& __exec, _forwarditerator1 __first, _forwarditerator1 __last, _forwarditerator2 __result, _predicate __pred);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Predicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+remove_copy_if(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, _Predicate __pred);
 
-template<class _executionpolicy, class _forwarditerator1, class _forwarditerator2, class _tp>
-__pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator2>
-remove_copy(_executionpolicy&& __exec, _forwarditerator1 __first, _forwarditerator1 __last, _forwarditerator2 __result, const _tp& __value);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+remove_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, const _Tp& __value);
 
-template<class _executionpolicy, class _forwarditerator, class _unarypredicate>
-__pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator>
-remove_if(_executionpolicy&& __exec, _forwarditerator __first, _forwarditerator __last, _unarypredicate __pred);
+template<class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+remove_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred);
 
-template<class _executionpolicy, class _forwarditerator, class _tp>
-__pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator>
-remove(_executionpolicy&& __exec, _forwarditerator __first, _forwarditerator __last, const _tp& __value);
+template<class _ExecutionPolicy, class _ForwardIterator, class _tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+remove(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _tp& __value);
 
 // [alg.unique]
 
-template<class _executionpolicy, class _forwarditerator, class _binarypredicate>
-__pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator>
-unique(_executionpolicy&& __exec, _forwarditerator __first, _forwarditerator __last, _binarypredicate __pred);
+template<class _ExecutionPolicy, class _ForwardIterator, class _BinaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+unique(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _BinaryPredicate __pred);
 
-template<class _executionpolicy, class _forwarditerator>
-__pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator>
-unique(_executionpolicy&& __exec, _forwarditerator __first, _forwarditerator __last);
+template<class _ExecutionPolicy, class _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+unique(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last);
 
-template<class _executionpolicy, class _forwarditerator1, class _forwarditerator2, class _binarypredicate>
-__pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator2>
-unique_copy(_executionpolicy&& __exec, _forwarditerator1 __first, _forwarditerator1 __last, _forwarditerator2 __result, _binarypredicate __pred);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+unique_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, _BinaryPredicate __pred);
 
-template<class _executionpolicy, class _forwarditerator1, class _forwarditerator2>
-__pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator2>
-unique_copy(_executionpolicy&& __exec, _forwarditerator1 __first, _forwarditerator1 __last, _forwarditerator2 __result);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+unique_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result);
 
 // [alg.reverse]
 
-template<class _executionpolicy, class _bidirectionaliterator>
-__pstl::internal::enable_if_execution_policy<_executionpolicy, void>
-reverse(_executionpolicy&& __exec, _bidirectionaliterator __first, _bidirectionaliterator __last);
+template<class _ExecutionPolicy, class _BidirectionalIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+reverse(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __last);
 
 template<class _ExecutionPolicy, class _BidirectionalIterator, class _ForwardIterator>
 __pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
@@ -354,12 +354,12 @@ partial_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAc
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _RandomAccessIterator, class _Compare>
 __pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator>
-partial_sort_copy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _RandomAccessIterator d_first, _RandomAccessIterator d_last,
+partial_sort_copy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _RandomAccessIterator __d_first, _RandomAccessIterator __d_last,
                   _Compare __comp);
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _RandomAccessIterator>
 __pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator>
-partial_sort_copy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _RandomAccessIterator d_first, _RandomAccessIterator d_last);
+partial_sort_copy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _RandomAccessIterator __d_first, _RandomAccessIterator __d_last);
 
 // [is.sorted]
 template<class _ExecutionPolicy, class _ForwardIterator, class _Compare>
@@ -397,7 +397,7 @@ merge(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 _
 template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator>
 __pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 merge(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
-      _ForwardIterator d_first);
+      _ForwardIterator __d_first);
 
 template< class _ExecutionPolicy, class _BidirectionalIterator, class _Compare>
 __pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>

--- a/include/pstl/internal/glue_algorithm_defs.h
+++ b/include/pstl/internal/glue_algorithm_defs.h
@@ -30,119 +30,119 @@ namespace std {
 
 // [alg.any_of]
 
-template<class _ExecutionPolicy, class _ForwardIterator, class ___Predicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
-any_of(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, ___Predicate __pred);
+template<class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+any_of(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred);
 
 // [alg.all_of]
 
-template<class _ExecutionPolicy, class _ForwardIterator, class ___Predicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
-all_of(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, ___Predicate __pred);
+template<class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+all_of(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred);
 
 // [alg.none_of]
 
-template<class _ExecutionPolicy, class _ForwardIterator, class ___Predicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
-none_of(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, ___Predicate __pred);
+template<class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+none_of(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred);
 
 // [alg.foreach]
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _Function>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
 for_each(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Function __f);
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Function>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 for_each_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n, _Function __f);
 
 // [alg.find]
 
-template<class _ExecutionPolicy, class _ForwardIterator, class ___Predicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
-find_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, ___Predicate __pred);
+template<class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+find_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred);
 
-template<class _ExecutionPolicy, class _ForwardIterator, class ___Predicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
-find_if_not(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, ___Predicate __pred);
+template<class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+find_if_not(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred);
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _Tp>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 find(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value);
 
 // [alg.find.end]
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
 find_end(_ExecutionPolicy &&__exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last,
          _BinaryPredicate __pred);
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
 find_end(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last);
 
 // [alg.find_first_of]
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
 find_first_of(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last,
               _BinaryPredicate __pred);
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
 find_first_of(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last);
 
 // [alg.adjacent_find]
 
 template< class _ExecutionPolicy, class _ForwardIterator >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 adjacent_find(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last);
 
 template< class _ExecutionPolicy, class _ForwardIterator, class _BinaryPredicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 adjacent_find(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _BinaryPredicate __pred);
 
 // [alg.count]
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _Tp>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy,typename iterator_traits<_ForwardIterator>::difference_type>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,typename iterator_traits<_ForwardIterator>::difference_type>
 count(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value);
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy,typename iterator_traits<_ForwardIterator>::difference_type>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,typename iterator_traits<_ForwardIterator>::difference_type>
 count_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred);
 
 // [alg.search]
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
 search(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last,
        _BinaryPredicate __pred);
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
 search(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last);
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp, class _BinaryPredicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 search_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Size __count, const _Tp& __value, _BinaryPredicate __pred);
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 search_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Size __count, const _Tp& __value);
 
 // [alg.copy]
 
 template<class _executionpolicy, class _forwarditerator1, class _forwarditerator2>
-pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator2>
+__pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator2>
 copy(_executionpolicy&& __exec, _forwarditerator1 __first, _forwarditerator1 __last, _forwarditerator2 __result);
 
 template<class _executionpolicy, class _forwarditerator1, class _size, class _forwarditerator2>
-pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator2>
+__pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator2>
 copy_n(_executionpolicy&& __exec, _forwarditerator1 __first, _size __n, _forwarditerator2 __result);
 
 template<class _executionpolicy, class _forwarditerator1, class _forwarditerator2, class _predicate>
-pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator2>
+__pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator2>
 copy_if(_executionpolicy&& __exec,
         _forwarditerator1 __first, _forwarditerator1 __last,
         _forwarditerator2 result, _predicate __pred);
@@ -150,373 +150,373 @@ copy_if(_executionpolicy&& __exec,
 // [alg.swap]
 
 template<class _executionpolicy, class _forwarditerator1, class _forwarditerator2>
-pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator2>
+__pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator2>
 swap_ranges(_executionpolicy&& __exec, _forwarditerator1 __first1, _forwarditerator1 __last1, _forwarditerator2 __first2);
 
 // [alg.transform]
 
 template<class _executionpolicy, class _forwarditerator1, class _forwarditerator2, class _unaryoperation>
-pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator2>
+__pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator2>
 transform( _executionpolicy&& __exec, _forwarditerator1 __first, _forwarditerator1 __last, _forwarditerator2 __result, _unaryoperation __op );
 
 template<class _executionpolicy, class _forwarditerator1, class _forwarditerator2, class _forwarditerator, class _binaryoperation>
-pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator>
+__pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator>
 transform(_executionpolicy&& __exec, _forwarditerator1 __first1, _forwarditerator1 __last1, _forwarditerator2 __first2, _forwarditerator __result,
           _binaryoperation __op);
 
 // [alg.replace]
 
 template<class _executionpolicy, class _forwarditerator, class _unarypredicate, class _tp>
-pstl::internal::enable_if_execution_policy<_executionpolicy, void>
+__pstl::internal::enable_if_execution_policy<_executionpolicy, void>
 replace_if(_executionpolicy&& __exec, _forwarditerator __first, _forwarditerator __last, _unarypredicate __pred, const _tp& __new_value);
 
 template<class _executionpolicy, class _forwarditerator, class _tp>
-pstl::internal::enable_if_execution_policy<_executionpolicy, void>
+__pstl::internal::enable_if_execution_policy<_executionpolicy, void>
 replace(_executionpolicy&& __exec, _forwarditerator __first, _forwarditerator __last, const _tp& __old_value, const _tp& __new_value);
 
 template<class _executionpolicy, class _forwarditerator1, class _forwarditerator2, class _unarypredicate, class _tp>
-pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator2>
+__pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator2>
 replace_copy_if(_executionpolicy&& __exec, _forwarditerator1 __first, _forwarditerator1 __last, _forwarditerator2 __result, _unarypredicate __pred,
                 const _tp& __new_value);
 
 template<class _executionpolicy, class _forwarditerator1, class _forwarditerator2, class _tp>
-pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator2>
+__pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator2>
 replace_copy(_executionpolicy&& __exec, _forwarditerator1 __first, _forwarditerator1 __last, _forwarditerator2 __result, const _tp& __old_value,
              const _tp& __new_value);
 
 // [alg.fill]
 
 template <class _executionpolicy, class _forwarditerator, class _tp>
-pstl::internal::enable_if_execution_policy<_executionpolicy, void>
+__pstl::internal::enable_if_execution_policy<_executionpolicy, void>
 fill( _executionpolicy&& __exec, _forwarditerator __first, _forwarditerator __last, const _tp& __value );
 
 template< class _executionpolicy, class _forwarditerator, class _size, class _tp>
-pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator>
+__pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator>
 fill_n( _executionpolicy&& __exec, _forwarditerator __first, _size __count, const _tp& __value );
 
 // [alg.generate]
 template< class _executionpolicy, class _forwarditerator, class _generator>
-pstl::internal::enable_if_execution_policy<_executionpolicy, void>
+__pstl::internal::enable_if_execution_policy<_executionpolicy, void>
 generate( _executionpolicy&& __exec, _forwarditerator __first, _forwarditerator __last, _generator __g );
 
 template< class _executionpolicy, class _forwarditerator, class _size, class _generator>
-pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator>
+__pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator>
 generate_n( _executionpolicy&& __exec, _forwarditerator __first, _size count, _generator __g );
 
 // [alg.remove]
 
 template<class _executionpolicy, class _forwarditerator1, class _forwarditerator2, class _predicate>
-pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator2>
+__pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator2>
 remove_copy_if(_executionpolicy&& __exec, _forwarditerator1 __first, _forwarditerator1 __last, _forwarditerator2 __result, _predicate __pred);
 
 template<class _executionpolicy, class _forwarditerator1, class _forwarditerator2, class _tp>
-pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator2>
+__pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator2>
 remove_copy(_executionpolicy&& __exec, _forwarditerator1 __first, _forwarditerator1 __last, _forwarditerator2 __result, const _tp& __value);
 
 template<class _executionpolicy, class _forwarditerator, class _unarypredicate>
-pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator>
+__pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator>
 remove_if(_executionpolicy&& __exec, _forwarditerator __first, _forwarditerator __last, _unarypredicate __pred);
 
 template<class _executionpolicy, class _forwarditerator, class _tp>
-pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator>
+__pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator>
 remove(_executionpolicy&& __exec, _forwarditerator __first, _forwarditerator __last, const _tp& __value);
 
 // [alg.unique]
 
 template<class _executionpolicy, class _forwarditerator, class _binarypredicate>
-pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator>
+__pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator>
 unique(_executionpolicy&& __exec, _forwarditerator __first, _forwarditerator __last, _binarypredicate __pred);
 
 template<class _executionpolicy, class _forwarditerator>
-pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator>
+__pstl::internal::enable_if_execution_policy<_executionpolicy, _forwarditerator>
 unique(_executionpolicy&& __exec, _forwarditerator __first, _forwarditerator __last);
 
 template<class _executionpolicy, class _forwarditerator1, class _forwarditerator2, class _binarypredicate>
-pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator2>
+__pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator2>
 unique_copy(_executionpolicy&& __exec, _forwarditerator1 __first, _forwarditerator1 __last, _forwarditerator2 __result, _binarypredicate __pred);
 
 template<class _executionpolicy, class _forwarditerator1, class _forwarditerator2>
-pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator2>
+__pstl::internal::enable_if_execution_policy<_executionpolicy,_forwarditerator2>
 unique_copy(_executionpolicy&& __exec, _forwarditerator1 __first, _forwarditerator1 __last, _forwarditerator2 __result);
 
 // [alg.reverse]
 
 template<class _executionpolicy, class _bidirectionaliterator>
-pstl::internal::enable_if_execution_policy<_executionpolicy, void>
+__pstl::internal::enable_if_execution_policy<_executionpolicy, void>
 reverse(_executionpolicy&& __exec, _bidirectionaliterator __first, _bidirectionaliterator __last);
 
 template<class _ExecutionPolicy, class _BidirectionalIterator, class _ForwardIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 reverse_copy(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __last, _ForwardIterator __d_first);
 
 // [alg.rotate]
 
 template<class _ExecutionPolicy, class _ForwardIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 rotate(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __middle, _ForwardIterator __last);
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
 rotate_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __middle, _ForwardIterator1 __last, _ForwardIterator2 __result);
 
 // [alg.partitions]
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
 is_partitioned(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred);
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 partition(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred);
 
 template<class _ExecutionPolicy, class _BidirectionalIterator, class _UnaryPredicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _BidirectionalIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _BidirectionalIterator>
 stable_partition(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __last, _UnaryPredicate __pred);
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _ForwardIterator1, class _ForwardIterator2, class _UnaryPredicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
 partition_copy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _ForwardIterator1 __out_true, _ForwardIterator2 __out_false,
                _UnaryPredicate __pred);
 
 // [alg.sort]
 
 template<class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
 sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp);
 
 template<class _ExecutionPolicy, class _RandomAccessIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
 sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last);
 
 // [stable.sort]
 
 template<class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
 stable_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp);
 
 template<class _ExecutionPolicy, class _RandomAccessIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
 stable_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last);
 
 // [mismatch]
 
 template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
 mismatch(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
          _BinaryPredicate pred);
 
 template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
 mismatch(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _BinaryPredicate __pred);
 
 template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2 >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
 mismatch(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2);
 
 template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2 >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
 mismatch(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2);
 
 // [alg.equal]
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
 equal(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _BinaryPredicate __p);
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
 equal(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2);
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
 equal(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2, _BinaryPredicate __p);
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
 equal(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2);
 
 // [alg.move]
 template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2 >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
 move(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __d_first);
 
 // [partial.sort]
 
 template<class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
 partial_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator middle, _RandomAccessIterator __last, _Compare __comp);
 
 template<class _ExecutionPolicy, class _RandomAccessIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
 partial_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator middle, _RandomAccessIterator __last);
 
 // [partial.sort.copy]
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _RandomAccessIterator, class _Compare>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator>
 partial_sort_copy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _RandomAccessIterator d_first, _RandomAccessIterator d_last,
                   _Compare __comp);
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _RandomAccessIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator>
 partial_sort_copy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _RandomAccessIterator d_first, _RandomAccessIterator d_last);
 
 // [is.sorted]
 template<class _ExecutionPolicy, class _ForwardIterator, class _Compare>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 is_sorted_until(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Compare __comp);
 
 template<class _ExecutionPolicy, class _ForwardIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 is_sorted_until(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last);
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _Compare>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
 is_sorted(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Compare __comp);
 
 template<class _ExecutionPolicy, class _ForwardIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
 is_sorted(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last);
 
 // [alg.nth.element]
 
 template<class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
 nth_element(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __nth, _RandomAccessIterator __last, _Compare __comp);
 
 template<class _ExecutionPolicy, class _RandomAccessIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
 nth_element(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __nth, _RandomAccessIterator __last);
 
 // [alg.merge]
 template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator, class _Compare>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 merge(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
       _ForwardIterator d_first, _Compare __comp);
 
 template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 merge(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
       _ForwardIterator d_first);
 
 template< class _ExecutionPolicy, class _BidirectionalIterator, class _Compare>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
 inplace_merge(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __middle, _BidirectionalIterator __last, _Compare __comp);
 
 template< class _ExecutionPolicy, class _BidirectionalIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
 inplace_merge(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __middle, _BidirectionalIterator __last);
 
 // [includes]
 
 template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Compare>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
 includes(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2, _Compare __comp);
 
 template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
 includes(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2);
 
 // [set.union]
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator, class _Compare>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 set_union(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
           _ForwardIterator __result, _Compare __comp);
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 set_union(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
           _ForwardIterator2 __last2, _ForwardIterator __result);
 
 // [set.intersection]
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator, class _Compare>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 set_intersection(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
                  _ForwardIterator __result, _Compare __comp);
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 set_intersection(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
                  _ForwardIterator __result);
 
 // [set.difference]
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator, class _Compare>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 set_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
                _ForwardIterator __result, _Compare __comp);
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 set_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
                _ForwardIterator __result);
 
 // [set.symmetric.difference]
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator, class _Compare>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 set_symmetric_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
                          _ForwardIterator result, _Compare __comp);
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 set_symmetric_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
                          _ForwardIterator __result);
 
 // [is.heap]
 template< class _ExecutionPolicy, class _RandomAccessIterator, class _Compare >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator>
 is_heap_until(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp);
 
 template< class _ExecutionPolicy, class _RandomAccessIterator >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator>
 is_heap_until(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last);
 
 template< class _ExecutionPolicy, class _RandomAccessIterator, class _Compare >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
 is_heap(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp);
 
 template< class _ExecutionPolicy, class _RandomAccessIterator >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
 is_heap(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last);
 
 // [alg.min.max]
 
 template< class _ExecutionPolicy, class _ForwardIterator, class _Compare >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 min_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Compare __comp);
 
 template< class _ExecutionPolicy, class _ForwardIterator >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 min_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last);
 
 template< class _ExecutionPolicy, class _ForwardIterator, class _Compare >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 max_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Compare __comp);
 
 template< class _ExecutionPolicy, class _ForwardIterator >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 max_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last);
 
 template< class _ExecutionPolicy, class _ForwardIterator, class _Compare >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator, _ForwardIterator>>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator, _ForwardIterator>>
 minmax_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Compare __comp);
 
 template< class _ExecutionPolicy, class _ForwardIterator >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator, _ForwardIterator>>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator, _ForwardIterator>>
 minmax_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last);
 
 // [alg.lex.comparison]
 
 template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Compare >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
 lexicographical_compare(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
                         _Compare __comp);
 
 template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2 >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
 lexicographical_compare(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2);
 
 } // namespace std

--- a/include/pstl/internal/glue_algorithm_impl.h
+++ b/include/pstl/internal/glue_algorithm_impl.h
@@ -68,9 +68,9 @@ for_each(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator _
         internal::is_parallelization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec));
 }
 
-template<class _ExecutionPolicy, class _ForwardIterator, class Size, class _Function>
+template<class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Function>
 __pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
-for_each_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, Size __n, _Function __f) {
+for_each_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n, _Function __f) {
     using namespace __pstl;
     return internal::pattern_walk1_n(__first, __n, __f,
                                      internal::is_vectorization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec),
@@ -95,11 +95,11 @@ find_if_not(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterato
     return std::find_if(__exec, __first, __last, __pstl::internal::not_pred<_Predicate>(__pred));
 }
 
-template<class _ExecutionPolicy, class _ForwardIterator, class T>
+template<class _ExecutionPolicy, class _ForwardIterator, class _Tp>
 __pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 find(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last,
-     const T& __value) {
-     return std::find_if(__exec, __first, __last, __pstl::internal::equal_value<T>(__value));
+     const _Tp& __value) {
+     return std::find_if(__exec, __first, __last, __pstl::internal::equal_value<_Tp>(__value));
 }
 
 // [alg.find.end]
@@ -198,9 +198,9 @@ search(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 _
     return std::search(std::forward<_ExecutionPolicy>(__exec), __first, __last, __s_first, __s_last, __pstl::internal::pstl_equal());
 }
 
-template<class _ExecutionPolicy, class _ForwardIterator, class Size, class T, class _BinaryPredicate>
+template<class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp, class _BinaryPredicate>
 __pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
-search_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, Size __count, const T& __value, _BinaryPredicate __pred) {
+search_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Size __count, const _Tp& __value, _BinaryPredicate __pred) {
     using namespace __pstl;
     return internal::pattern_search_n(__first, __last, __count, __value, __pred,
                                       internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
@@ -494,13 +494,13 @@ partition(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator 
                                        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
 }
 
-template<class _ExecutionPolicy, class BidirectionalIterator, class _UnaryPredicate>
-__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, BidirectionalIterator>
-stable_partition(_ExecutionPolicy&& __exec, BidirectionalIterator __first, BidirectionalIterator __last, _UnaryPredicate __pred) {
+template<class _ExecutionPolicy, class _BidirectionalIterator, class _UnaryPredicate>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _BidirectionalIterator>
+stable_partition(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __last, _UnaryPredicate __pred) {
     using namespace __pstl;
     return internal::pattern_stable_partition(__first, __last, __pred,
-                                              internal::is_vectorization_preferred<_ExecutionPolicy, BidirectionalIterator>(__exec),
-                                              internal::is_parallelization_preferred<_ExecutionPolicy, BidirectionalIterator>(__exec));
+                                              internal::is_vectorization_preferred<_ExecutionPolicy, _BidirectionalIterator>(__exec),
+                                              internal::is_parallelization_preferred<_ExecutionPolicy, _BidirectionalIterator>(__exec));
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _ForwardIterator1, class _ForwardIterator2, class _UnaryPredicate>

--- a/include/pstl/internal/glue_algorithm_impl.h
+++ b/include/pstl/internal/glue_algorithm_impl.h
@@ -31,127 +31,129 @@
 namespace std {
 // [alg.any_of]
 
-template<class ExecutionPolicy, class ForwardIterator, class Predicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-any_of(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, Predicate pred) {
-    using namespace pstl::internal;
-    return pattern_any_of( first, last, pred,
-                           is_vectorization_preferred<ExecutionPolicy,ForwardIterator>(exec),
-                           is_parallelization_preferred<ExecutionPolicy,ForwardIterator>(exec));
+template<class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+any_of(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred) {
+    using namespace pstl;
+    return internal::pattern_any_of( __first, __last, __pred,
+                                     internal::is_vectorization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec),
+                                     internal::is_parallelization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec));
 }
 
 // [alg.all_of]
 
-template<class ExecutionPolicy, class ForwardIterator, class Pred>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-all_of(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, Pred pred) {
-    return !any_of(std::forward<ExecutionPolicy>(exec), first, last, pstl::internal::not_pred<Pred>(pred));
+template<class _ExecutionPolicy, class _ForwardIterator, class _Pred>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+all_of(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Pred __pred) {
+    return !std::any_of(std::forward<_ExecutionPolicy>(__exec), __first, __last, pstl::internal::not_pred<_Pred>(__pred));
 }
 
 // [alg.none_of]
 
-template<class ExecutionPolicy, class ForwardIterator, class Predicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-none_of(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, Predicate pred) {
-    return !any_of( std::forward<ExecutionPolicy>(exec), first, last, pred );
+template<class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+none_of(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred) {
+    return !std::any_of( std::forward<_ExecutionPolicy>(__exec), __first, __last, __pred );
 }
 
 // [alg.foreach]
 
-template<class ExecutionPolicy, class ForwardIterator, class Function>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-for_each(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, Function f) {
-    using namespace pstl::internal;
-    pattern_walk1(
-        first, last, f,
-        is_vectorization_preferred<ExecutionPolicy,ForwardIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy,ForwardIterator>(exec));
+template<class _ExecutionPolicy, class _ForwardIterator, class _Function>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+for_each(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Function __f) {
+    using namespace pstl;
+    internal::pattern_walk1(
+        __first, __last, __f,
+        internal::is_vectorization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec));
 }
 
-template<class ExecutionPolicy, class ForwardIterator, class Size, class Function>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-for_each_n(ExecutionPolicy&& exec, ForwardIterator first, Size n, Function f) {
-    using namespace pstl::internal;
-    return pattern_walk1_n(first, n, f,
-        is_vectorization_preferred<ExecutionPolicy,ForwardIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy,ForwardIterator>(exec));
+template<class _ExecutionPolicy, class _ForwardIterator, class Size, class _Function>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+for_each_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, Size __n, _Function __f) {
+    using namespace pstl;
+    return internal::pattern_walk1_n(__first, __n, __f,
+                                     internal::is_vectorization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec),
+                                     internal::is_parallelization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec));
 }
 
 // [alg.find]
 
-template<class ExecutionPolicy, class ForwardIterator, class Predicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-find_if(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, Predicate pred) {
+template<class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+find_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred) {
     using namespace pstl::internal;
-    return pattern_find_if( first, last, pred,
-        is_vectorization_preferred<ExecutionPolicy,ForwardIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy,ForwardIterator>(exec));
+    return pattern_find_if( __first, __last, __pred,
+        is_vectorization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec),
+        is_parallelization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec));
 }
 
-template<class ExecutionPolicy, class ForwardIterator, class Predicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-find_if_not(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last,
-Predicate pred) {
-    return find_if(exec, first, last, pstl::internal::not_pred<Predicate>(pred));
+template<class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+find_if_not(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last,
+            _Predicate __pred) {
+    return std::find_if(__exec, __first, __last, pstl::internal::not_pred<_Predicate>(__pred));
 }
 
-template<class ExecutionPolicy, class ForwardIterator, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-find(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last,
-const T& value) {
-    return find_if(exec, first, last, pstl::internal::equal_value<T>(value));
+template<class _ExecutionPolicy, class _ForwardIterator, class T>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+find(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last,
+     const T& __value) {
+     return std::find_if(__exec, __first, __last, pstl::internal::equal_value<T>(__value));
 }
 
 // [alg.find.end]
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class BinaryPredicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator1>
-find_end(ExecutionPolicy &&exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 s_first, ForwardIterator2 s_last, BinaryPredicate pred) {
-    using namespace pstl::internal;
-    return pattern_find_end(first, last, s_first, s_last, pred,
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec),
-        is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec));
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+find_end(_ExecutionPolicy &&__exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last,
+         _BinaryPredicate __pred) {
+    using namespace pstl;
+    return internal::pattern_find_end(__first, __last, __s_first, __s_last, __pred,
+                                      internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
+                                      internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
 }
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator1>
-find_end(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 s_first, ForwardIterator2 s_last) {
-    return find_end(std::forward<ExecutionPolicy>(exec), first, last, s_first, s_last, pstl::internal::pstl_equal());
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+find_end(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last) {
+    return std::find_end(std::forward<_ExecutionPolicy>(__exec), __first, __last, __s_first, __s_last, pstl::internal::pstl_equal());
 }
 
 // [alg.find_first_of]
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class BinaryPredicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator1>
-find_first_of(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 s_first, ForwardIterator2 s_last, BinaryPredicate pred) {
-    using namespace pstl::internal;
-    return pattern_find_first_of(first, last, s_first, s_last, pred,
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec),
-        is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec));
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+find_first_of(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last,
+              _BinaryPredicate __pred) {
+    using namespace pstl;
+    return internal::pattern_find_first_of(__first, __last, __s_first, __s_last, __pred,
+                                           internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
+                                           internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
 }
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator1>
-find_first_of(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 s_first, ForwardIterator2 s_last) {
-    return find_first_of(std::forward<ExecutionPolicy>(exec), first, last, s_first, s_last, pstl::internal::pstl_equal());
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+find_first_of(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last) {
+    return std::find_first_of(std::forward<_ExecutionPolicy>(__exec), __first, __last, __s_first, __s_last, pstl::internal::pstl_equal());
 }
 
 // [alg.adjacent_find]
-template< class ExecutionPolicy, class ForwardIterator >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-adjacent_find(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last) {
-    typedef typename iterator_traits<ForwardIterator>::value_type value_type;
-    using namespace pstl::internal;
-    return pattern_adjacent_find(first, last, std::equal_to<value_type>(),
-       is_parallelization_preferred<ExecutionPolicy, ForwardIterator>(exec),
-       is_vectorization_preferred<ExecutionPolicy, ForwardIterator>(exec), /*first_semantic*/ false);
+template< class _ExecutionPolicy, class _ForwardIterator >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+adjacent_find(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last) {
+    typedef typename iterator_traits<_ForwardIterator>::value_type value_type;
+    using namespace pstl;
+    return internal::pattern_adjacent_find(__first, __last, std::equal_to<value_type>(),
+                                           internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+                                           internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec), /*first_semantic*/ false);
 }
 
-template< class ExecutionPolicy, class ForwardIterator, class BinaryPredicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-adjacent_find(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, BinaryPredicate pred) {
-    using namespace pstl::internal;
-    return pattern_adjacent_find(first, last, pred,
-       is_parallelization_preferred<ExecutionPolicy, ForwardIterator>(exec),
-       is_vectorization_preferred<ExecutionPolicy, ForwardIterator>(exec), /*first_semantic*/ false);
+template< class _ExecutionPolicy, class _ForwardIterator, class _BinaryPredicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+adjacent_find(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _BinaryPredicate __pred) {
+    using namespace pstl;
+    return internal::pattern_adjacent_find(__first, __last, __pred,
+                                           internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+                                           internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec), /*first_semantic*/ false);
 }
 
 // [alg.count]
@@ -159,765 +161,790 @@ adjacent_find(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator las
 // Implementation note: count and count_if call the pattern directly instead of calling std::transform_reduce
 // so that we do not have to include <numeric>.
 
-template<class ExecutionPolicy, class ForwardIterator, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,typename iterator_traits<ForwardIterator>::difference_type>
-count(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, const T& value) {
-    typedef typename iterator_traits<ForwardIterator>::value_type value_type;
-    using namespace pstl::internal;
-    return pattern_count(first, last, [&value](const value_type& x) {return value==x;},
-       is_parallelization_preferred<ExecutionPolicy,ForwardIterator>(exec),
-       is_vectorization_preferred<ExecutionPolicy,ForwardIterator>(exec));
+template<class _ExecutionPolicy, class _ForwardIterator, class _Tp>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy,typename iterator_traits<_ForwardIterator>::difference_type>
+count(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value) {
+    typedef typename iterator_traits<_ForwardIterator>::value_type value_type;
+    using namespace pstl;
+    return internal::pattern_count(__first, __last, [&__value](const value_type& __x) {return __value == __x;},
+                                   internal::is_parallelization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec),
+                                   internal::is_vectorization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec));
 }
 
-template<class ExecutionPolicy, class ForwardIterator, class Predicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,typename iterator_traits<ForwardIterator>::difference_type>
-count_if(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, Predicate pred) {
-    using namespace pstl::internal;
-    return pattern_count(first, last, pred,
-       is_parallelization_preferred<ExecutionPolicy,ForwardIterator>(exec),
-       is_vectorization_preferred<ExecutionPolicy,ForwardIterator>(exec));
+template<class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy,typename iterator_traits<_ForwardIterator>::difference_type>
+count_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred) {
+    using namespace pstl;
+    return internal::pattern_count(__first, __last, __pred,
+                                   internal::is_parallelization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec),
+                                   internal::is_vectorization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec));
 }
 
 // [alg.search]
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class BinaryPredicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator1>
-search(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 s_first, ForwardIterator2 s_last, BinaryPredicate pred) {
-    using namespace pstl::internal;
-    return pattern_search(first, last, s_first, s_last, pred,
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec),
-        is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec));
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+search(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last,
+       _BinaryPredicate __pred) {
+    using namespace pstl;
+    return internal::pattern_search(__first, __last, __s_first, __s_last, __pred,
+                                    internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
+                                    internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
 }
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator1>
-search(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 s_first, ForwardIterator2 s_last) {
-    return search(std::forward<ExecutionPolicy>(exec), first, last, s_first, s_last, pstl::internal::pstl_equal());
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+search(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last) {
+    return std::search(std::forward<_ExecutionPolicy>(__exec), __first, __last, __s_first, __s_last, pstl::internal::pstl_equal());
 }
 
-template<class ExecutionPolicy, class ForwardIterator, class Size, class T, class BinaryPredicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-search_n(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, Size count, const T& value, BinaryPredicate pred) {
-    using namespace pstl::internal;
-    return pattern_search_n(first, last, count, value, pred,
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy, ForwardIterator>(exec));
+template<class _ExecutionPolicy, class _ForwardIterator, class Size, class T, class _BinaryPredicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+search_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, Size __count, const T& __value, _BinaryPredicate __pred) {
+    using namespace pstl;
+    return internal::pattern_search_n(__first, __last, __count, __value, __pred,
+                                      internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+                                      internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
 }
 
-template<class ExecutionPolicy, class ForwardIterator, class Size, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-search_n(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, Size count, const T& value) {
-    return search_n(exec, first, last, count, value, std::equal_to<typename iterator_traits<ForwardIterator>::value_type>());
+template<class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+search_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Size __count, const _Tp& __value) {
+    return std::search_n(__exec, __first, __last, __count, __value, std::equal_to<typename iterator_traits<_ForwardIterator>::value_type>());
 }
 
 // [alg.copy]
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
-copy(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result) {
-    using namespace pstl::internal;
-    const auto is_vector = is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result) {
+    using namespace pstl;
+    const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec);
 
-    return pattern_walk2_brick(first, last, result, [is_vector](ForwardIterator1 begin, ForwardIterator1 end, ForwardIterator2 res){
-        return brick_copy(begin, end, res, is_vector);
-    }, is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec));
+    return internal::pattern_walk2_brick(__first, __last, __result, [__is_vector](_ForwardIterator1 __begin, _ForwardIterator1 __end, _ForwardIterator2 __res){
+        return internal::brick_copy(__begin, __end, __res, __is_vector);
+      }, internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
 }
 
-template<class ExecutionPolicy, class ForwardIterator1, class Size, class ForwardIterator2>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
-copy_n(ExecutionPolicy&& exec, ForwardIterator1 first, Size n, ForwardIterator2 result) {
-    using namespace pstl::internal;
-    const auto is_vector = is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _Size, class _ForwardIterator2>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+copy_n(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _Size __n, _ForwardIterator2 __result) {
+    using namespace pstl;
+    const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec);
 
-    return pattern_walk2_brick_n(first, n, result, [is_vector](ForwardIterator1 begin, Size sz, ForwardIterator2 res){
-        return brick_copy_n(begin, sz, res, is_vector);
-    }, is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec));
+    return internal::pattern_walk2_brick_n(__first, __n, __result, [__is_vector](_ForwardIterator1 __begin, _Size __sz, _ForwardIterator2 __res){
+        return internal::brick_copy_n(__begin, __sz, __res, __is_vector);
+      }, internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
 }
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class Predicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
-copy_if(ExecutionPolicy&& exec,
-        ForwardIterator1 first, ForwardIterator1 last,
-        ForwardIterator2 result, Predicate pred) {
-    using namespace pstl::internal;
-    return pattern_copy_if(
-        first, last, result, pred,
-        is_vectorization_preferred<ExecutionPolicy,ForwardIterator1,ForwardIterator2>(exec),
-        is_parallelization_preferred<ExecutionPolicy,ForwardIterator1,ForwardIterator2>(exec));
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Predicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+copy_if(_ExecutionPolicy&& __exec,
+        _ForwardIterator1 __first, _ForwardIterator1 __last,
+        _ForwardIterator2 __result, _Predicate __pred) {
+    using namespace pstl;
+    return internal::pattern_copy_if(__first, __last, __result, __pred,
+                                     internal::is_vectorization_preferred<_ExecutionPolicy,_ForwardIterator1,_ForwardIterator2>(__exec),
+                                     internal::is_parallelization_preferred<_ExecutionPolicy,_ForwardIterator1,_ForwardIterator2>(__exec));
 }
 
 // [alg.swap]
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator2>
-swap_ranges(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2) {
-    using namespace pstl::internal;
-    return pattern_swap_ranges(first1, last1, first2,
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec),
-        is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec));
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+swap_ranges(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2) {
+    using namespace pstl;
+    return internal::pattern_swap_ranges(__first1, __last1, __first2,
+                                         internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
+                                         internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
 }
 
 // [alg.transform]
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class UnaryOperation>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
-transform( ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, UnaryOperation op ) {
-    typedef typename iterator_traits<ForwardIterator1>::value_type input_type;
-    typedef typename iterator_traits<ForwardIterator2>::reference output_type;
-    using namespace pstl::internal;
-    return pattern_walk2(first, last, result,
-        [op](input_type x, output_type y ) mutable { y = op(x);},
-        is_vectorization_preferred<ExecutionPolicy,ForwardIterator1,ForwardIterator2>(exec),
-        is_parallelization_preferred<ExecutionPolicy,ForwardIterator1,ForwardIterator2>(exec));
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _UnaryOperation>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+transform( _ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, _UnaryOperation __op ) {
+    typedef typename iterator_traits<_ForwardIterator1>::value_type _InputType;
+    typedef typename iterator_traits<_ForwardIterator2>::reference _OutputType;
+    using namespace pstl;
+    return internal::pattern_walk2(__first, __last, __result,
+        [__op](_InputType __x, _OutputType __y ) mutable { __y = __op(__x);},
+                                   internal::is_vectorization_preferred<_ExecutionPolicy,_ForwardIterator1,_ForwardIterator2>(__exec),
+                                   internal::is_parallelization_preferred<_ExecutionPolicy,_ForwardIterator1,_ForwardIterator2>(__exec));
 }
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class ForwardIterator, class BinaryOperation>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator>
-transform( ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator result, BinaryOperation op ) {
-    typedef typename iterator_traits<ForwardIterator1>::value_type input1_type;
-    typedef typename iterator_traits<ForwardIterator2>::value_type input2_type;
-    typedef typename iterator_traits<ForwardIterator>::reference output_type;
-    using namespace pstl::internal;
-    return pattern_walk3(first1, last1, first2, result, [op]( input1_type x, input2_type y, output_type z ) mutable {z = op(x,y);},
-        is_vectorization_preferred<ExecutionPolicy,ForwardIterator1,ForwardIterator2,ForwardIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy,ForwardIterator1,ForwardIterator2,ForwardIterator>(exec));
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator, class _BinaryOperation>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator>
+transform( _ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator __result,
+           _BinaryOperation __op ) {
+    typedef typename iterator_traits<_ForwardIterator1>::value_type _Input1Type;
+    typedef typename iterator_traits<_ForwardIterator2>::value_type _Input2Type;
+    typedef typename iterator_traits<_ForwardIterator>::reference _OutputType;
+    using namespace pstl;
+    return internal::pattern_walk3(__first1, __last1, __first2, __result, [__op]( _Input1Type x, _Input2Type y, _OutputType z ) mutable { z = __op(x,y); },
+                                   internal::is_vectorization_preferred<_ExecutionPolicy,_ForwardIterator1,_ForwardIterator2,_ForwardIterator>(__exec),
+                                   internal::is_parallelization_preferred<_ExecutionPolicy,_ForwardIterator1,_ForwardIterator2,_ForwardIterator>(__exec));
 }
 
 // [alg.replace]
 
-template<class ExecutionPolicy, class ForwardIterator, class UnaryPredicate, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-replace_if(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, UnaryPredicate pred, const T& new_value) {
-    using namespace pstl::internal;
-    typedef typename iterator_traits<ForwardIterator>::reference element_type;
-    pattern_walk1(first, last, [&pred, &new_value] (element_type elem) {
-            if (pred(elem)) {
-                elem = new_value;
-            }
-        },
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy, ForwardIterator>(exec));
+template<class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate, class _Tp>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+replace_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred, const _Tp& __new_value) {
+    using namespace pstl;
+    typedef typename iterator_traits<_ForwardIterator>::reference _ElementType;
+    internal::pattern_walk1(__first, __last, [&__pred, &__new_value] (_ElementType __elem) {
+                  if (__pred(__elem)) {
+                      __elem = __new_value;
+                  }
+              },
+          internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+          internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
 }
 
-template<class ExecutionPolicy, class ForwardIterator, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-replace(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, const T& old_value, const T& new_value) {
-    replace_if(exec, first, last, pstl::internal::equal_value<T>(old_value), new_value);
+template<class _ExecutionPolicy, class _ForwardIterator, class _Tp>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+replace(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __old_value, const _Tp& __new_value) {
+    std::replace_if(__exec, __first, __last, pstl::internal::equal_value<_Tp>(__old_value), __new_value);
 }
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class UnaryPredicate, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator2>
-replace_copy_if(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, UnaryPredicate pred, const T& new_value) {
-    typedef typename iterator_traits<ForwardIterator1>::value_type input_type;
-    typedef typename iterator_traits<ForwardIterator2>::reference output_type;
-    using namespace pstl::internal;
-    return pattern_walk2(
-        first, last, result,
-        [pred, &new_value](input_type x, output_type y) mutable { y = pred(x) ? new_value : x; },
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec),
-        is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec));
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _UnaryPredicate, class _Tp>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+replace_copy_if(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, _UnaryPredicate __pred,
+                const _Tp& __new_value) {
+    typedef typename iterator_traits<_ForwardIterator1>::value_type _InputType;
+    typedef typename iterator_traits<_ForwardIterator2>::reference _OutputType;
+    using namespace pstl;
+    return internal::pattern_walk2(__first, __last, __result,
+        [__pred, &__new_value](_InputType __x, _OutputType __y) mutable { __y = __pred(__x) ? __new_value : __x; },
+                                   internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
+                                   internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
 }
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator2>
-replace_copy(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, const T& old_value, const T& new_value) {
-    return replace_copy_if(exec, first, last, result, pstl::internal::equal_value<T>(old_value), new_value);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+replace_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result,
+             const _Tp& __old_value, const _Tp& __new_value) {
+    return std::replace_copy_if(__exec, __first, __last, __result, pstl::internal::equal_value<_Tp>(__old_value), __new_value);
 }
 
 // [alg.fill]
 
-template <class ExecutionPolicy, class ForwardIterator, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-fill( ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, const T& value ) {
-    using namespace pstl::internal;
-    pattern_fill(first, last, value,
-        is_parallelization_preferred<ExecutionPolicy,ForwardIterator>(exec),
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator>(exec));
+template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+fill( _ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value ) {
+    using namespace pstl;
+    internal::pattern_fill(__first, __last, __value,
+                           internal::is_parallelization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec),
+                           internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
 }
 
-template< class ExecutionPolicy, class ForwardIterator, class Size, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-fill_n( ExecutionPolicy&& exec, ForwardIterator first, Size count, const T& value ) {
-    if(count <= 0)
-        return first;
+template< class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+fill_n( _ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __count, const _Tp& __value ) {
+    if(__count <= 0)
+        return __first;
 
-    using namespace pstl::internal;
-    return pattern_fill_n(first, count, value,
-        is_parallelization_preferred<ExecutionPolicy, ForwardIterator>(exec),
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator>(exec));
+    using namespace pstl;
+    return internal::pattern_fill_n(__first, __count, __value,
+                                    internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+                                    internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
 }
 
 // [alg.generate]
-template< class ExecutionPolicy, class ForwardIterator, class Generator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-generate( ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, Generator g ) {
-    using namespace pstl::internal;
-    pattern_generate(first, last, g,
-        is_parallelization_preferred<ExecutionPolicy,ForwardIterator>(exec),
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator>(exec));
+template< class _ExecutionPolicy, class _ForwardIterator, class _Generator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+generate( _ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Generator __g ) {
+    using namespace pstl;
+    internal::pattern_generate(__first, __last, __g,
+                               internal::is_parallelization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec),
+                               internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
 }
 
-template< class ExecutionPolicy, class ForwardIterator, class Size, class Generator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-generate_n( ExecutionPolicy&& exec, ForwardIterator first, Size count, Generator g ) {
-    if(count <= 0)
-        return first;
+template< class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Generator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+generate_n( _ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __count, _Generator __g ) {
+    if(__count <= 0)
+        return __first;
 
-    using namespace pstl::internal;
-    return pattern_generate_n(first, count, g,
-        is_parallelization_preferred<ExecutionPolicy, ForwardIterator>(exec),
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator>(exec));
+    using namespace pstl;
+    return internal::pattern_generate_n(__first, __count, __g,
+                                        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+                                        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
 }
 
 // [alg.remove]
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class Predicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
-remove_copy_if(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, Predicate pred) {
-    return copy_if( exec, first, last, result, pstl::internal::not_pred<Predicate>(pred));
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Predicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+remove_copy_if(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, _Predicate __pred) {
+    return std::copy_if( __exec, __first, __last, __result, pstl::internal::not_pred<_Predicate>(__pred));
 }
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
-remove_copy(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, const T& value) {
-    return copy_if( exec, first, last, result, pstl::internal::not_equal_value<T>(value));
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+remove_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, const _Tp& __value) {
+    return std::copy_if( __exec, __first, __last, __result, pstl::internal::not_equal_value<_Tp>(__value));
 }
 
-template<class ExecutionPolicy, class ForwardIterator, class UnaryPredicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-remove_if(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, UnaryPredicate pred) {
-    using namespace pstl::internal;
-    return pattern_remove_if(first, last, pred,
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy, ForwardIterator>(exec));
+template<class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+remove_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred) {
+    using namespace pstl;
+    return internal::pattern_remove_if(__first, __last, __pred,
+                                       internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+                                       internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
 }
 
-template<class ExecutionPolicy, class ForwardIterator, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-remove(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, const T& value) {
-    return remove_if(exec, first, last, pstl::internal::equal_value<T>(value));
+template<class _ExecutionPolicy, class _ForwardIterator, class _Tp>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+remove(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value) {
+    return std::remove_if(__exec, __first, __last, pstl::internal::equal_value<_Tp>(__value));
 }
 
 // [alg.unique]
 
-template<class ExecutionPolicy, class ForwardIterator, class BinaryPredicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-unique(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, BinaryPredicate pred) {
-    using namespace pstl::internal;
-    return pattern_unique(first, last, pred,
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy, ForwardIterator>(exec));
+template<class _ExecutionPolicy, class _ForwardIterator, class _BinaryPredicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+unique(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _BinaryPredicate __pred) {
+    using namespace pstl;
+    return internal::pattern_unique(__first, __last, __pred,
+                                    internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+                                    internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
 }
 
-template<class ExecutionPolicy, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-unique(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last) {
-    return unique(exec, first, last, pstl::internal::pstl_equal());
+template<class _ExecutionPolicy, class _ForwardIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+unique(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last) {
+    return std::unique(__exec, __first, __last, pstl::internal::pstl_equal());
 }
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class BinaryPredicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
-unique_copy(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, BinaryPredicate pred) {
-    using namespace pstl::internal;
-    return pattern_unique_copy(first, last, result, pred,
-        is_vectorization_preferred<ExecutionPolicy,ForwardIterator1,ForwardIterator2>(exec),
-        is_parallelization_preferred<ExecutionPolicy,ForwardIterator1,ForwardIterator2>(exec));
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+unique_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, _BinaryPredicate __pred) {
+    using namespace pstl;
+    return internal::pattern_unique_copy(__first, __last, __result, __pred,
+                                         internal::is_vectorization_preferred<_ExecutionPolicy,_ForwardIterator1,_ForwardIterator2>(__exec),
+                                         internal::is_parallelization_preferred<_ExecutionPolicy,_ForwardIterator1,_ForwardIterator2>(__exec));
 }
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
-unique_copy(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result) {
-    return unique_copy( exec, first, last, result, pstl::internal::pstl_equal() );
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+unique_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result) {
+    return std::unique_copy( __exec, __first, __last, __result, pstl::internal::pstl_equal() );
 }
 
 // [alg.reverse]
 
-template<class ExecutionPolicy, class BidirectionalIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-reverse(ExecutionPolicy&& exec, BidirectionalIterator first, BidirectionalIterator last) {
-    using namespace pstl::internal;
-    pattern_reverse(first, last,
-        is_vectorization_preferred<ExecutionPolicy, BidirectionalIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy, BidirectionalIterator>(exec));
+template<class _ExecutionPolicy, class _BidirectionalIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+reverse(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __last) {
+    using namespace pstl;
+    internal::pattern_reverse(__first, __last,
+                              internal::is_vectorization_preferred<_ExecutionPolicy, _BidirectionalIterator>(__exec),
+                              internal::is_parallelization_preferred<_ExecutionPolicy, _BidirectionalIterator>(__exec));
 }
 
-template<class ExecutionPolicy, class BidirectionalIterator, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-reverse_copy(ExecutionPolicy&& exec, BidirectionalIterator first, BidirectionalIterator last, ForwardIterator d_first) {
-    using namespace pstl::internal;
-    return pattern_reverse_copy(first, last, d_first,
-        is_vectorization_preferred<ExecutionPolicy, BidirectionalIterator, ForwardIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy, BidirectionalIterator, ForwardIterator>(exec));
+template<class _ExecutionPolicy, class _BidirectionalIterator, class _ForwardIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+reverse_copy(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __last, _ForwardIterator __d_first) {
+    using namespace pstl;
+    return internal::pattern_reverse_copy(__first, __last, __d_first,
+                                          internal::is_vectorization_preferred<_ExecutionPolicy, _BidirectionalIterator, _ForwardIterator>(__exec),
+                                          internal::is_parallelization_preferred<_ExecutionPolicy, _BidirectionalIterator, _ForwardIterator>(__exec));
 }
 
 // [alg.rotate]
 
-template<class ExecutionPolicy, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-rotate(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator middle, ForwardIterator last) {
-    using namespace pstl::internal;
-    return pattern_rotate(first, middle, last,
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy, ForwardIterator>(exec));
+template<class _ExecutionPolicy, class _ForwardIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+rotate(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __middle, _ForwardIterator __last) {
+    using namespace pstl;
+    return internal::pattern_rotate(__first, __middle, __last,
+                                    internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+                                    internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
 }
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator2>
-rotate_copy(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 middle, ForwardIterator1 last, ForwardIterator2 result) {
-    using namespace pstl::internal;
-    return pattern_rotate_copy(first, middle, last, result,
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec),
-        is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec));
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+rotate_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __middle, _ForwardIterator1 __last, _ForwardIterator2 __result) {
+    using namespace pstl;
+    return internal::pattern_rotate_copy(__first, __middle, __last, __result,
+                                         internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
+                                         internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
 }
 
 // [alg.partitions]
 
-template<class ExecutionPolicy, class ForwardIterator, class UnaryPredicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-is_partitioned(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, UnaryPredicate pred) {
-    using namespace pstl::internal;
-    return pattern_is_partitioned(first, last, pred,
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy, ForwardIterator>(exec));
+template<class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+is_partitioned(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred) {
+    using namespace pstl;
+    return internal::pattern_is_partitioned(__first, __last, __pred,
+                                            internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+                                            internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
 }
 
-template<class ExecutionPolicy, class ForwardIterator, class UnaryPredicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-partition(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, UnaryPredicate pred) {
-    using namespace pstl::internal;
-    return pattern_partition(first, last, pred,
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy, ForwardIterator>(exec));
+template<class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+partition(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred) {
+    using namespace pstl;
+    return internal::pattern_partition(__first, __last, __pred,
+                                       internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+                                       internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
 }
 
-template<class ExecutionPolicy, class BidirectionalIterator, class UnaryPredicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, BidirectionalIterator>
-stable_partition(ExecutionPolicy&& exec, BidirectionalIterator first, BidirectionalIterator last, UnaryPredicate pred) {
-    using namespace pstl::internal;
-    return pattern_stable_partition(first, last, pred,
-        is_vectorization_preferred<ExecutionPolicy, BidirectionalIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy, BidirectionalIterator>(exec));
+template<class _ExecutionPolicy, class BidirectionalIterator, class _UnaryPredicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, BidirectionalIterator>
+stable_partition(_ExecutionPolicy&& __exec, BidirectionalIterator __first, BidirectionalIterator __last, _UnaryPredicate __pred) {
+    using namespace pstl;
+    return internal::pattern_stable_partition(__first, __last, __pred,
+                                              internal::is_vectorization_preferred<_ExecutionPolicy, BidirectionalIterator>(__exec),
+                                              internal::is_parallelization_preferred<_ExecutionPolicy, BidirectionalIterator>(__exec));
 }
 
-template<class ExecutionPolicy, class ForwardIterator, class ForwardIterator1, class ForwardIterator2, class UnaryPredicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, std::pair<ForwardIterator1, ForwardIterator2>>
-partition_copy(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, ForwardIterator1 out_true, ForwardIterator2 out_false, UnaryPredicate pred) {
-    using namespace pstl::internal;
-    return pattern_partition_copy(first, last, out_true, out_false, pred,
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator, ForwardIterator1, ForwardIterator2>(exec),
-        is_parallelization_preferred<ExecutionPolicy, ForwardIterator, ForwardIterator1, ForwardIterator2>(exec));
+template<class _ExecutionPolicy, class _ForwardIterator, class _ForwardIterator1, class _ForwardIterator2, class _UnaryPredicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
+partition_copy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _ForwardIterator1 __out_true, _ForwardIterator2 __out_false,
+               _UnaryPredicate __pred) {
+    using namespace pstl;
+    return internal::pattern_partition_copy(__first, __last, __out_true, __out_false, __pred,
+                                            internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator, _ForwardIterator1, _ForwardIterator2>(__exec),
+                                            internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator, _ForwardIterator1, _ForwardIterator2>(__exec));
 }
 
 // [alg.sort]
 
-template<class ExecutionPolicy, class RandomAccessIterator, class Compare>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-sort(ExecutionPolicy&& exec, RandomAccessIterator first, RandomAccessIterator last, Compare comp) {
-    typedef typename iterator_traits<RandomAccessIterator>::value_type input_type;
-    using namespace pstl::internal;
-    return pattern_sort(first, last, comp,
-        is_vectorization_preferred<ExecutionPolicy,RandomAccessIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy,RandomAccessIterator>(exec),
-        typename std::is_move_constructible<input_type>::type());
+template<class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp) {
+    typedef typename iterator_traits<_RandomAccessIterator>::value_type _InputType;
+    using namespace pstl;
+    return internal::pattern_sort(__first, __last, __comp,
+                                  internal::is_vectorization_preferred<_ExecutionPolicy,_RandomAccessIterator>(__exec),
+                                  internal::is_parallelization_preferred<_ExecutionPolicy,_RandomAccessIterator>(__exec),
+        typename std::is_move_constructible<_InputType>::type());
 }
 
-template<class ExecutionPolicy, class RandomAccessIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-sort(ExecutionPolicy&& exec, RandomAccessIterator first, RandomAccessIterator last) {
-    typedef typename iterator_traits<RandomAccessIterator>::value_type input_type;
-    sort(exec, first, last, std::less<input_type>());
+template<class _ExecutionPolicy, class _RandomAccessIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last) {
+    typedef typename iterator_traits<_RandomAccessIterator>::value_type _InputType;
+    std::sort(__exec, __first, __last, std::less<_InputType>());
 }
 
 // [stable.sort]
 
-template<class ExecutionPolicy, class RandomAccessIterator, class Compare>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-stable_sort(ExecutionPolicy&& exec, RandomAccessIterator first, RandomAccessIterator last, Compare comp) {
-    using namespace pstl::internal;
-    return pattern_stable_sort(first, last, comp,
-        is_vectorization_preferred<ExecutionPolicy,RandomAccessIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy,RandomAccessIterator>(exec));
+template<class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+stable_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp) {
+    using namespace pstl;
+    return internal::pattern_stable_sort(__first, __last, __comp,
+                                         internal::is_vectorization_preferred<_ExecutionPolicy,_RandomAccessIterator>(__exec),
+                                         internal::is_parallelization_preferred<_ExecutionPolicy,_RandomAccessIterator>(__exec));
 }
 
-template<class ExecutionPolicy, class RandomAccessIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-stable_sort(ExecutionPolicy&& exec, RandomAccessIterator first, RandomAccessIterator last) {
-    typedef typename iterator_traits<RandomAccessIterator>::value_type input_type;
-    stable_sort(exec, first, last, std::less<input_type>());
+template<class _ExecutionPolicy, class _RandomAccessIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+stable_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last) {
+    typedef typename iterator_traits<_RandomAccessIterator>::value_type _InputType;
+    std::stable_sort(__exec, __first, __last, std::less<_InputType>());
 }
 
 // [mismatch]
 
-template< class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class BinaryPredicate >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, std::pair<ForwardIterator1, ForwardIterator2>>
-mismatch(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2, BinaryPredicate pred) {
-    using namespace pstl::internal;
-    return pattern_mismatch(first1, last1, first2, last2, pred,
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec),
-        is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec));
+template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
+mismatch(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
+         _BinaryPredicate __pred) {
+    using namespace pstl;
+    return internal::pattern_mismatch(__first1, __last1, __first2, __last2, __pred,
+                                      internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
+                                      internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
 }
 
-template< class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class BinaryPredicate >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, std::pair<ForwardIterator1, ForwardIterator2>>
-mismatch(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, BinaryPredicate pred) {
-    return mismatch(exec, first1, last1, first2, std::next(first2, std::distance(first1, last1)), pred);
+template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
+mismatch(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _BinaryPredicate __pred) {
+    return std::mismatch(__exec, __first1, __last1, __first2, std::next(__first2, std::distance(__first1, __last1)), __pred);
 }
 
-template< class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2 >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, std::pair<ForwardIterator1, ForwardIterator2>>
-mismatch(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2) {
-return mismatch(std::forward<ExecutionPolicy>(exec), first1, last1, first2, last2, pstl::internal::pstl_equal());}
+template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2 >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
+mismatch(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2) {
+    return std::mismatch(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, pstl::internal::pstl_equal());
+}
 
-template< class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2 >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, std::pair<ForwardIterator1, ForwardIterator2>>
-mismatch(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2) {
-    return mismatch(exec, first1, last1, first2, std::next(first2, std::distance(first1, last1)));
+template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2 >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
+mismatch(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2) {
+    return std::mismatch(__exec, __first1, __last1, __first2, std::next(__first2, std::distance(__first1, __last1)));
 }
 
 // [alg.equal]
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class BinaryPredicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-equal(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, BinaryPredicate p) {
-    using namespace pstl::internal;
-    return pattern_equal(first1, last1, first2, p,
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator1>(exec),
-        is_parallelization_preferred<ExecutionPolicy, ForwardIterator1>(exec)
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+equal(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _BinaryPredicate __p) {
+    using namespace pstl;
+    return internal::pattern_equal(__first1, __last1, __first2, __p,
+                                   internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1>(__exec),
+                                   internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1>(__exec)
         );
 }
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-equal(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2) {
-    return equal(exec, first1, last1, first2, pstl::internal::pstl_equal());
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+equal(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2) {
+    return std::equal(__exec, __first1, __last1, __first2, pstl::internal::pstl_equal());
 }
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class BinaryPredicate>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-equal(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2, BinaryPredicate p) {
-    if ( std::distance(first1, last1) == std::distance(first2, last2) )
-        return std::equal(first1, last1, first2, p);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+equal(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
+      _BinaryPredicate __p) {
+    if ( std::distance(__first1, __last1) == std::distance(__first2, __last2) )
+        return std::equal(__first1, __last1, __first2, __p);
     else
         return false;
 }
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-equal(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2) {
-    return equal(first1, last1, first2, pstl::internal::pstl_equal());
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+equal(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2) {
+    return std::equal(__first1, __last1, __first2, pstl::internal::pstl_equal());
 }
 
 // [alg.move]
-template< class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2 >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator2>
-move(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 d_first) {
-    using namespace pstl::internal;
-    const auto is_vector = is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec);
+template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2 >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+move(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __d_first) {
+    using namespace pstl;
+    const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec);
 
-    return pattern_walk2_brick(first, last, d_first, [is_vector](ForwardIterator1 begin, ForwardIterator1 end, ForwardIterator2 res) {
-        return brick_move(begin, end, res, is_vector);
-    }, is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec));
+    return internal::pattern_walk2_brick(__first, __last, __d_first, [__is_vector](_ForwardIterator1 __begin, _ForwardIterator1 __end, _ForwardIterator2 __res) {
+        return internal::brick_move(__begin, __end, __res, __is_vector);
+      }, internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
 }
 
 // [partial.sort]
 
-template<class ExecutionPolicy, class RandomAccessIterator, class Compare>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-partial_sort(ExecutionPolicy&& exec, RandomAccessIterator first, RandomAccessIterator middle, RandomAccessIterator last, Compare comp) {
-    using namespace pstl::internal;
-    pattern_partial_sort(first, middle, last, comp,
-        is_vectorization_preferred<ExecutionPolicy, RandomAccessIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy, RandomAccessIterator>(exec));
+template<class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+partial_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __middle, _RandomAccessIterator __last, _Compare __comp) {
+    using namespace pstl;
+    internal::pattern_partial_sort(__first, __middle, __last, __comp,
+                                   internal::is_vectorization_preferred<_ExecutionPolicy, _RandomAccessIterator>(__exec),
+                                   internal::is_parallelization_preferred<_ExecutionPolicy, _RandomAccessIterator>(__exec));
 }
 
-template<class ExecutionPolicy, class RandomAccessIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-partial_sort(ExecutionPolicy&& exec, RandomAccessIterator first, RandomAccessIterator middle, RandomAccessIterator last) {
-    typedef typename iterator_traits<RandomAccessIterator>::value_type input_type;
-    partial_sort(exec, first, middle, last, std::less<input_type>());
+template<class _ExecutionPolicy, class _RandomAccessIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+partial_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __middle, _RandomAccessIterator __last) {
+    typedef typename iterator_traits<_RandomAccessIterator>::value_type _InputType;
+    std::partial_sort(__exec, __first, __middle, __last, std::less<_InputType>());
 }
 
 // [partial.sort.copy]
 
-template<class ExecutionPolicy, class ForwardIterator, class RandomAccessIterator, class Compare>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, RandomAccessIterator>
-partial_sort_copy(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, RandomAccessIterator d_first, RandomAccessIterator d_last, Compare comp) {
-    using namespace pstl::internal;
-    return pattern_partial_sort_copy(first, last, d_first, d_last, comp,
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator, RandomAccessIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy, ForwardIterator, RandomAccessIterator>(exec));
+template<class _ExecutionPolicy, class _ForwardIterator, class _RandomAccessIterator, class _Compare>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator>
+partial_sort_copy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last,
+                  _RandomAccessIterator __d_first, _RandomAccessIterator __d_last,
+                  _Compare __comp) {
+    using namespace pstl;
+    return internal::pattern_partial_sort_copy(__first, __last, __d_first, __d_last, __comp,
+                                               internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator, _RandomAccessIterator>(__exec),
+                                               internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator, _RandomAccessIterator>(__exec));
 }
 
-template<class ExecutionPolicy, class ForwardIterator, class RandomAccessIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, RandomAccessIterator>
-partial_sort_copy(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, RandomAccessIterator d_first, RandomAccessIterator d_last) {
-    return partial_sort_copy(std::forward<ExecutionPolicy>(exec), first, last, d_first, d_last, pstl::internal::pstl_less());
+template<class _ExecutionPolicy, class _ForwardIterator, class _RandomAccessIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator>
+partial_sort_copy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last,
+                  _RandomAccessIterator __d_first, _RandomAccessIterator __d_last) {
+    return std::partial_sort_copy(std::forward<_ExecutionPolicy>(__exec), __first, __last, __d_first, __d_last, pstl::internal::pstl_less());
 }
 
 // [is.sorted]
-template<class ExecutionPolicy, class ForwardIterator, class Compare>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-is_sorted_until(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, Compare comp) {
-    using namespace pstl::internal;
-    const ForwardIterator res = pattern_adjacent_find(first, last, pstl::internal::reorder_pred<Compare>(comp),
-        is_parallelization_preferred<ExecutionPolicy, ForwardIterator>(exec),
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator>(exec), /*first_semantic*/ false);
-    return res==last ? last : std::next(res);
+template<class _ExecutionPolicy, class _ForwardIterator, class _Compare>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+is_sorted_until(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Compare __comp) {
+    using namespace pstl;
+    const _ForwardIterator __res = internal::pattern_adjacent_find(__first, __last, pstl::internal::reorder_pred<_Compare>(__comp),
+                                                                   internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+                                                                   internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec), /*first_semantic*/ false);
+    return __res == __last ? __last : std::next(__res);
 }
 
-template<class ExecutionPolicy, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-is_sorted_until(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last) {
-    typedef typename iterator_traits<ForwardIterator>::value_type input_type;
-    return is_sorted_until(exec, first, last, std::less<input_type>());
+template<class _ExecutionPolicy, class _ForwardIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+is_sorted_until(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last) {
+    typedef typename iterator_traits<_ForwardIterator>::value_type _InputType;
+    return is_sorted_until(__exec, __first, __last, std::less<_InputType>());
 }
 
-template<class ExecutionPolicy, class ForwardIterator, class Compare>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-is_sorted(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, Compare comp) {
-    using namespace pstl::internal;
-    return pattern_adjacent_find(first, last, reorder_pred<Compare>(comp),
-        is_parallelization_preferred<ExecutionPolicy, ForwardIterator>(exec),
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator>(exec), /*or_semantic*/ true)==last;
+template<class _ExecutionPolicy, class _ForwardIterator, class _Compare>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+is_sorted(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Compare __comp) {
+    using namespace pstl;
+    return internal::pattern_adjacent_find(__first, __last, internal::reorder_pred<_Compare>(__comp),
+                                           internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+                                           internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec), /*or_semantic*/ true) == __last;
 }
 
-template<class ExecutionPolicy, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-is_sorted(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last) {
-    typedef typename iterator_traits<ForwardIterator>::value_type input_type;
-    return is_sorted(exec, first, last, std::less<input_type>());
+template<class _ExecutionPolicy, class _ForwardIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+is_sorted(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last) {
+    typedef typename iterator_traits<_ForwardIterator>::value_type _InputType;
+    return std::is_sorted(__exec, __first, __last, std::less<_InputType>());
 }
 
 // [alg.nth.element]
 
-template<class ExecutionPolicy, class RandomAccessIterator, class Compare>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-nth_element(ExecutionPolicy&& exec, RandomAccessIterator first, RandomAccessIterator nth, RandomAccessIterator last, Compare comp) {
-    using namespace pstl::internal;
-    pattern_nth_element(first, nth, last, comp,
-        is_vectorization_preferred<ExecutionPolicy, RandomAccessIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy, RandomAccessIterator>(exec));
+template<class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+nth_element(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __nth, _RandomAccessIterator __last, _Compare __comp) {
+    using namespace pstl;
+    internal::pattern_nth_element(__first, __nth, __last, __comp,
+                                  internal::is_vectorization_preferred<_ExecutionPolicy, _RandomAccessIterator>(__exec),
+                                  internal::is_parallelization_preferred<_ExecutionPolicy, _RandomAccessIterator>(__exec));
 }
 
-template<class ExecutionPolicy, class RandomAccessIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-nth_element(ExecutionPolicy&& exec, RandomAccessIterator first, RandomAccessIterator nth, RandomAccessIterator last) {
-    typedef typename iterator_traits<RandomAccessIterator>::value_type input_type;
-    nth_element(exec, first, nth, last, std::less<input_type>());
+template<class _ExecutionPolicy, class _RandomAccessIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+nth_element(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __nth, _RandomAccessIterator __last) {
+    typedef typename iterator_traits<_RandomAccessIterator>::value_type _InputType;
+    std::nth_element(__exec, __first, __nth, __last, std::less<_InputType>());
 }
 
 // [alg.merge]
-template< class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class ForwardIterator, class Compare>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-merge(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2, ForwardIterator d_first, Compare comp) {
-    using namespace pstl::internal;
-    return pattern_merge(first1, last1, first2, last2, d_first, comp,
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2, ForwardIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2, ForwardIterator>(exec));
+template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator, class _Compare>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+merge(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
+      _ForwardIterator __d_first, _Compare __comp) {
+    using namespace pstl;
+    return internal::pattern_merge(__first1, __last1, __first2, __last2, __d_first, __comp,
+                                   internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2, _ForwardIterator>(__exec),
+                                   internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2, _ForwardIterator>(__exec));
 }
 
-template< class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-merge(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2, ForwardIterator d_first) {
-    return merge(std::forward<ExecutionPolicy>(exec), first1, last1, first2, last2, d_first, pstl::internal::pstl_less());
+template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+merge(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
+      _ForwardIterator __d_first) {
+    return std::merge(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __d_first, pstl::internal::pstl_less());
 }
 
-template< class ExecutionPolicy, class BidirectionalIterator, class Compare>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-inplace_merge(ExecutionPolicy&& exec, BidirectionalIterator first, BidirectionalIterator middle, BidirectionalIterator last, Compare comp) {
-    using namespace pstl::internal;
-    pattern_inplace_merge(first, middle, last, comp,
-        is_vectorization_preferred<ExecutionPolicy, BidirectionalIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy, BidirectionalIterator>(exec));
+template< class _ExecutionPolicy, class _BidirectionalIterator, class _Compare>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+inplace_merge(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __middle, _BidirectionalIterator __last, _Compare __comp) {
+    using namespace pstl;
+    internal::pattern_inplace_merge(__first, __middle, __last, __comp,
+                                    internal::is_vectorization_preferred<_ExecutionPolicy, _BidirectionalIterator>(__exec),
+                                    internal::is_parallelization_preferred<_ExecutionPolicy, _BidirectionalIterator>(__exec));
 }
 
-template< class ExecutionPolicy, class BidirectionalIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-inplace_merge(ExecutionPolicy&& exec, BidirectionalIterator first, BidirectionalIterator middle, BidirectionalIterator last) {
-    typedef typename iterator_traits<BidirectionalIterator>::value_type input_type;
-    inplace_merge(exec, first, middle, last, std::less<input_type>());
+template< class _ExecutionPolicy, class _BidirectionalIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+inplace_merge(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __middle, _BidirectionalIterator __last) {
+    typedef typename iterator_traits<_BidirectionalIterator>::value_type _InputType;
+    std::inplace_merge(__exec, __first, __middle, __last, std::less<_InputType>());
 }
 
 // [includes]
 
-template< class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class Compare>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-includes(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2, Compare comp) {
-    using namespace pstl::internal;
-    return pattern_includes(first1, last1, first2, last2, comp,
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec),
-        is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec));
+template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Compare>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+includes(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
+         _Compare __comp) {
+    using namespace pstl;
+    return internal::pattern_includes(__first1, __last1, __first2, __last2, __comp,
+                                      internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
+                                      internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
 }
 
-template< class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-includes(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2) {
-    return includes(std::forward<ExecutionPolicy>(exec), first1, last1, first2, last2, pstl::internal::pstl_less());}
+template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+includes(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2) {
+    return includes(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, pstl::internal::pstl_less());}
 
 // [set.union]
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class ForwardIterator, class Compare>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-set_union(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2, ForwardIterator result, Compare comp) {
-    using namespace pstl::internal;
-    return pattern_set_union(first1, last1, first2, last2, result, comp,
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2, ForwardIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2, ForwardIterator>(exec));
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator, class _Compare>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+set_union(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
+          _ForwardIterator __result, _Compare __comp) {
+    using namespace pstl;
+    return internal::pattern_set_union(__first1, __last1, __first2, __last2, __result, __comp,
+                                       internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2, _ForwardIterator>(__exec),
+                                       internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2, _ForwardIterator>(__exec));
 }
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-set_union(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2,
-    ForwardIterator2 last2, ForwardIterator result) {
-    return set_union(std::forward<ExecutionPolicy>(exec), first1, last1, first2, last2, result, pstl::internal::pstl_less());
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+set_union(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+    _ForwardIterator2 __last2, _ForwardIterator __result) {
+    return set_union(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __result, pstl::internal::pstl_less());
 }
 
 // [set.intersection]
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class ForwardIterator, class Compare>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-set_intersection(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2, ForwardIterator result, Compare comp) {
-    using namespace pstl::internal;
-    return pattern_set_intersection(first1, last1, first2, last2, result, comp,
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2, ForwardIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2, ForwardIterator>(exec));
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator, class _Compare>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+set_intersection(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
+                 _ForwardIterator __result, _Compare __comp) {
+    using namespace pstl;
+    return internal::pattern_set_intersection(__first1, __last1, __first2, __last2, __result, __comp,
+                                              internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2, _ForwardIterator>(__exec),
+                                              internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2, _ForwardIterator>(__exec));
 }
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-set_intersection(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2, ForwardIterator result) {
-    return set_intersection(std::forward<ExecutionPolicy>(exec), first1, last1, first2, last2, result, pstl::internal::pstl_less());
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+set_intersection(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
+                 _ForwardIterator __result) {
+    return std::set_intersection(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __result, pstl::internal::pstl_less());
 }
 
 // [set.difference]
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class ForwardIterator, class Compare>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-set_difference(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2, ForwardIterator result, Compare comp) {
-    using namespace pstl::internal;
-    return pattern_set_difference(first1, last1, first2, last2, result, comp,
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2, ForwardIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2, ForwardIterator>(exec));
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator, class _Compare>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+set_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
+               _ForwardIterator __result, _Compare __comp) {
+    using namespace pstl;
+    return internal::pattern_set_difference(__first1, __last1, __first2, __last2, __result, __comp,
+                                            internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2, _ForwardIterator>(__exec),
+                                            internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2, _ForwardIterator>(__exec));
 }
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-set_difference(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2, ForwardIterator result) {
-    return set_difference(std::forward<ExecutionPolicy>(exec), first1, last1, first2, last2, result, pstl::internal::pstl_less());
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+set_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
+               _ForwardIterator __result) {
+    return std::set_difference(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __result, pstl::internal::pstl_less());
 }
 
 // [set.symmetric.difference]
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class ForwardIterator, class Compare>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-set_symmetric_difference(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2, ForwardIterator result, Compare comp) {
-    using namespace pstl::internal;
-    return pattern_set_symmetric_difference(first1, last1, first2, last2, result, comp,
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2, ForwardIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2, ForwardIterator>(exec));
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator, class _Compare>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+set_symmetric_difference(_ExecutionPolicy&& __exec,
+                         _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
+                         _ForwardIterator __result, _Compare __comp) {
+    using namespace pstl;
+    return internal::pattern_set_symmetric_difference(__first1, __last1, __first2, __last2, __result, __comp,
+                                                      internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2, _ForwardIterator>(__exec),
+                                                      internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2, _ForwardIterator>(__exec));
 }
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-set_symmetric_difference(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2, ForwardIterator result) {
-    return set_symmetric_difference(std::forward<ExecutionPolicy>(exec), first1, last1, first2, last2, result, pstl::internal::pstl_less());
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+set_symmetric_difference(_ExecutionPolicy&& __exec,
+                         _ForwardIterator1 __first1, _ForwardIterator1 __last1,
+                         _ForwardIterator2 __first2, _ForwardIterator2 __last2,
+                         _ForwardIterator __result) {
+    return std::set_symmetric_difference(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __result, pstl::internal::pstl_less());
 }
 
 // [is.heap]
-template< class ExecutionPolicy, class RandomAccessIterator, class Compare >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, RandomAccessIterator>
-is_heap_until(ExecutionPolicy&& exec, RandomAccessIterator first, RandomAccessIterator last, Compare comp) {
-    using namespace pstl::internal;
-    return pattern_is_heap_until(first, last, comp,
-        is_vectorization_preferred<ExecutionPolicy, RandomAccessIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy, RandomAccessIterator>(exec));
+template< class _ExecutionPolicy, class _RandomAccessIterator, class _Compare >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator>
+is_heap_until(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp) {
+    using namespace pstl;
+    return internal::pattern_is_heap_until(__first, __last, __comp,
+                                           internal::is_vectorization_preferred<_ExecutionPolicy, _RandomAccessIterator>(__exec),
+                                           internal::is_parallelization_preferred<_ExecutionPolicy, _RandomAccessIterator>(__exec));
 }
 
-template< class ExecutionPolicy, class RandomAccessIterator >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, RandomAccessIterator>
-is_heap_until(ExecutionPolicy&& exec, RandomAccessIterator first, RandomAccessIterator last) {
-    typedef typename iterator_traits<RandomAccessIterator>::value_type input_type;
-    return is_heap_until(exec, first, last, std::less<input_type>());
+template< class _ExecutionPolicy, class _RandomAccessIterator >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator>
+is_heap_until(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last) {
+    typedef typename iterator_traits<_RandomAccessIterator>::value_type _InputType;
+    return std::is_heap_until(__exec, __first, __last, std::less<_InputType>());
 }
 
-template< class ExecutionPolicy, class RandomAccessIterator, class Compare >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-is_heap(ExecutionPolicy&& exec, RandomAccessIterator first, RandomAccessIterator last, Compare comp) {
-    return is_heap_until(exec, first, last, comp) == last;
+template< class _ExecutionPolicy, class _RandomAccessIterator, class _Compare >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+is_heap(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp) {
+    return std::is_heap_until(__exec, __first, __last, __comp) == __last;
 }
 
-template< class ExecutionPolicy, class RandomAccessIterator >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-is_heap(ExecutionPolicy&& exec, RandomAccessIterator first, RandomAccessIterator last) {
-    typedef typename iterator_traits<RandomAccessIterator>::value_type input_type;
-    return is_heap(exec, first, last, std::less<input_type>());
+template< class _ExecutionPolicy, class _RandomAccessIterator >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+is_heap(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last) {
+    typedef typename iterator_traits<_RandomAccessIterator>::value_type _InputType;
+    return std::is_heap(__exec, __first, __last, std::less<_InputType>());
 }
 
 // [alg.min.max]
 
-template< class ExecutionPolicy, class ForwardIterator, class Compare >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-min_element(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, Compare comp) {
-    using namespace pstl::internal;
-    return pattern_min_element(first, last, comp,
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy, ForwardIterator>(exec));
+template< class _ExecutionPolicy, class _ForwardIterator, class _Compare >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+min_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Compare __comp) {
+    using namespace pstl;
+    return internal::pattern_min_element(__first, __last, __comp,
+                                         internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+                                         internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
 }
 
-template< class ExecutionPolicy, class ForwardIterator >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-min_element(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last) {
-    typedef typename iterator_traits<ForwardIterator>::value_type input_type;
-    return min_element(exec, first, last, std::less<input_type>());
+template< class _ExecutionPolicy, class _ForwardIterator >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+min_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last) {
+    typedef typename iterator_traits<_ForwardIterator>::value_type _InputType;
+    return std::min_element(__exec, __first, __last, std::less<_InputType>());
 }
 
-template< class ExecutionPolicy, class ForwardIterator, class Compare >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-max_element(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, Compare comp) {
-    using namespace pstl::internal;
-    return pattern_min_element(first, last, pstl::internal::reorder_pred<Compare>(comp),
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy, ForwardIterator>(exec));
+template< class _ExecutionPolicy, class _ForwardIterator, class _Compare >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+max_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Compare __comp) {
+    using namespace pstl;
+    return internal::pattern_min_element(__first, __last, pstl::internal::reorder_pred<_Compare>(__comp),
+                                         internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+                                         internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
 }
 
-template< class ExecutionPolicy, class ForwardIterator >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-max_element(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last) {
-    typedef typename iterator_traits<ForwardIterator>::value_type input_type;
-    return min_element(exec, first, last, pstl::internal::reorder_pred<std::less<input_type> >(std::less<input_type>()));
+template< class _ExecutionPolicy, class _ForwardIterator >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+max_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last) {
+    typedef typename iterator_traits<_ForwardIterator>::value_type _InputType;
+    return std::min_element(__exec, __first, __last, pstl::internal::reorder_pred<std::less<_InputType>>(std::less<_InputType>()));
 }
 
-template< class ExecutionPolicy, class ForwardIterator, class Compare >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, std::pair<ForwardIterator, ForwardIterator>>
-minmax_element(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, Compare comp) {
-    using namespace pstl::internal;
-    return pattern_minmax_element(first, last, comp,
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy, ForwardIterator>(exec));
+template< class _ExecutionPolicy, class _ForwardIterator, class _Compare >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator, _ForwardIterator>>
+minmax_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Compare __comp) {
+    using namespace pstl;
+    return internal::pattern_minmax_element(__first, __last, __comp,
+                                            internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
+                                            internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
 }
 
-template< class ExecutionPolicy, class ForwardIterator >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, std::pair<ForwardIterator, ForwardIterator>>
-minmax_element(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last) {
-    typedef typename iterator_traits<ForwardIterator>::value_type value_type;
-    return minmax_element(exec, first, last, std::less<value_type>());
+template< class _ExecutionPolicy, class _ForwardIterator >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator, _ForwardIterator>>
+minmax_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last) {
+    typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
+    return std::minmax_element(__exec, __first, __last, std::less<_ValueType>());
 }
 
 // [alg.lex.comparison]
 
-template< class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class Compare >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-lexicographical_compare(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2, Compare comp) {
-    using namespace pstl::internal;
-    return pattern_lexicographical_compare(first1, last1, first2, last2, comp,
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec),
-        is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec));
+template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Compare >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+lexicographical_compare(_ExecutionPolicy&& __exec,
+                        _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
+                        _Compare __comp) {
+    using namespace pstl;
+    return internal::pattern_lexicographical_compare(__first1, __last1, __first2, __last2, __comp,
+                                                     internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
+                                                     internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
 }
 
-template< class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2 >
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, bool>
-lexicographical_compare(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, ForwardIterator2 last2) {
-    return lexicographical_compare(std::forward<ExecutionPolicy>(exec), first1, last1, first2, last2, pstl::internal::pstl_less());
+template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2 >
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+lexicographical_compare(_ExecutionPolicy&& __exec,
+                        _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2) {
+    return std::lexicographical_compare(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, pstl::internal::pstl_less());
 }
 
 } // namespace std

--- a/include/pstl/internal/glue_algorithm_impl.h
+++ b/include/pstl/internal/glue_algorithm_impl.h
@@ -140,9 +140,9 @@ find_first_of(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIter
 template< class _ExecutionPolicy, class _ForwardIterator >
 __pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 adjacent_find(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last) {
-    typedef typename iterator_traits<_ForwardIterator>::value_type value_type;
+    typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
     using namespace __pstl;
-    return internal::pattern_adjacent_find(__first, __last, std::equal_to<value_type>(),
+    return internal::pattern_adjacent_find(__first, __last, std::equal_to<_ValueType>(),
                                            internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
                                            internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec), /*first_semantic*/ false);
 }
@@ -164,9 +164,9 @@ adjacent_find(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardItera
 template<class _ExecutionPolicy, class _ForwardIterator, class _Tp>
 __pstl::internal::enable_if_execution_policy<_ExecutionPolicy,typename iterator_traits<_ForwardIterator>::difference_type>
 count(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value) {
-    typedef typename iterator_traits<_ForwardIterator>::value_type value_type;
+    typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
     using namespace __pstl;
-    return internal::pattern_count(__first, __last, [&__value](const value_type& __x) {return __value == __x;},
+    return internal::pattern_count(__first, __last, [&__value](const _ValueType& __x) {return __value == __x;},
                                    internal::is_parallelization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec),
                                    internal::is_vectorization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec));
 }

--- a/include/pstl/internal/glue_algorithm_impl.h
+++ b/include/pstl/internal/glue_algorithm_impl.h
@@ -922,8 +922,4 @@ lexicographical_compare(ExecutionPolicy&& exec, ForwardIterator1 first1, Forward
 
 } // namespace std
 
-<<<<<<< HEAD
-=======
-#define __PSTL_glue_algorithm_impl_H_
->>>>>>> Refacor <algorithm> header
 #endif /* __PSTL_glue_algorithm_impl_H_ */

--- a/include/pstl/internal/glue_algorithm_impl.h
+++ b/include/pstl/internal/glue_algorithm_impl.h
@@ -922,4 +922,8 @@ lexicographical_compare(ExecutionPolicy&& exec, ForwardIterator1 first1, Forward
 
 } // namespace std
 
+<<<<<<< HEAD
+=======
+#define __PSTL_glue_algorithm_impl_H_
+>>>>>>> Refacor <algorithm> header
 #endif /* __PSTL_glue_algorithm_impl_H_ */

--- a/include/pstl/internal/glue_algorithm_impl.h
+++ b/include/pstl/internal/glue_algorithm_impl.h
@@ -32,9 +32,9 @@ namespace std {
 // [alg.any_of]
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
 any_of(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_any_of( __first, __last, __pred,
                                      internal::is_vectorization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec),
                                      internal::is_parallelization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec));
@@ -43,15 +43,15 @@ any_of(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __l
 // [alg.all_of]
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _Pred>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
 all_of(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Pred __pred) {
-    return !std::any_of(std::forward<_ExecutionPolicy>(__exec), __first, __last, pstl::internal::not_pred<_Pred>(__pred));
+    return !std::any_of(std::forward<_ExecutionPolicy>(__exec), __first, __last, __pstl::internal::not_pred<_Pred>(__pred));
 }
 
 // [alg.none_of]
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
 none_of(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred) {
     return !std::any_of( std::forward<_ExecutionPolicy>(__exec), __first, __last, __pred );
 }
@@ -59,9 +59,9 @@ none_of(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __
 // [alg.foreach]
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _Function>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
 for_each(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Function __f) {
-    using namespace pstl;
+    using namespace __pstl;
     internal::pattern_walk1(
         __first, __last, __f,
         internal::is_vectorization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec),
@@ -69,9 +69,9 @@ for_each(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator _
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator, class Size, class _Function>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 for_each_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, Size __n, _Function __f) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_walk1_n(__first, __n, __f,
                                      internal::is_vectorization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec),
                                      internal::is_parallelization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec));
@@ -80,77 +80,77 @@ for_each_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, Size __n, _Funct
 // [alg.find]
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 find_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred) {
-    using namespace pstl::internal;
-    return pattern_find_if( __first, __last, __pred,
-        is_vectorization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec),
-        is_parallelization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec));
+    using namespace __pstl;
+    return internal::pattern_find_if( __first, __last, __pred,
+                                      internal::is_vectorization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec),
+                                      internal::is_parallelization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec));
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 find_if_not(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last,
             _Predicate __pred) {
-    return std::find_if(__exec, __first, __last, pstl::internal::not_pred<_Predicate>(__pred));
+    return std::find_if(__exec, __first, __last, __pstl::internal::not_pred<_Predicate>(__pred));
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator, class T>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 find(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last,
      const T& __value) {
-     return std::find_if(__exec, __first, __last, pstl::internal::equal_value<T>(__value));
+     return std::find_if(__exec, __first, __last, __pstl::internal::equal_value<T>(__value));
 }
 
 // [alg.find.end]
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
 find_end(_ExecutionPolicy &&__exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last,
          _BinaryPredicate __pred) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_find_end(__first, __last, __s_first, __s_last, __pred,
                                       internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
                                       internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
 find_end(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last) {
-    return std::find_end(std::forward<_ExecutionPolicy>(__exec), __first, __last, __s_first, __s_last, pstl::internal::pstl_equal());
+    return std::find_end(std::forward<_ExecutionPolicy>(__exec), __first, __last, __s_first, __s_last, __pstl::internal::pstl_equal());
 }
 
 // [alg.find_first_of]
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
 find_first_of(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last,
               _BinaryPredicate __pred) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_find_first_of(__first, __last, __s_first, __s_last, __pred,
                                            internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
                                            internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
 find_first_of(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last) {
-    return std::find_first_of(std::forward<_ExecutionPolicy>(__exec), __first, __last, __s_first, __s_last, pstl::internal::pstl_equal());
+    return std::find_first_of(std::forward<_ExecutionPolicy>(__exec), __first, __last, __s_first, __s_last, __pstl::internal::pstl_equal());
 }
 
 // [alg.adjacent_find]
 template< class _ExecutionPolicy, class _ForwardIterator >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 adjacent_find(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last) {
     typedef typename iterator_traits<_ForwardIterator>::value_type value_type;
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_adjacent_find(__first, __last, std::equal_to<value_type>(),
                                            internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
                                            internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec), /*first_semantic*/ false);
 }
 
 template< class _ExecutionPolicy, class _ForwardIterator, class _BinaryPredicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 adjacent_find(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _BinaryPredicate __pred) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_adjacent_find(__first, __last, __pred,
                                            internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
                                            internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec), /*first_semantic*/ false);
@@ -162,19 +162,19 @@ adjacent_find(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardItera
 // so that we do not have to include <numeric>.
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _Tp>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy,typename iterator_traits<_ForwardIterator>::difference_type>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,typename iterator_traits<_ForwardIterator>::difference_type>
 count(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value) {
     typedef typename iterator_traits<_ForwardIterator>::value_type value_type;
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_count(__first, __last, [&__value](const value_type& __x) {return __value == __x;},
                                    internal::is_parallelization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec),
                                    internal::is_vectorization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec));
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _Predicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy,typename iterator_traits<_ForwardIterator>::difference_type>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,typename iterator_traits<_ForwardIterator>::difference_type>
 count_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Predicate __pred) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_count(__first, __last, __pred,
                                    internal::is_parallelization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec),
                                    internal::is_vectorization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec));
@@ -183,32 +183,32 @@ count_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator _
 // [alg.search]
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
 search(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last,
        _BinaryPredicate __pred) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_search(__first, __last, __s_first, __s_last, __pred,
                                     internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
                                     internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator1>
 search(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first, _ForwardIterator2 __s_last) {
-    return std::search(std::forward<_ExecutionPolicy>(__exec), __first, __last, __s_first, __s_last, pstl::internal::pstl_equal());
+    return std::search(std::forward<_ExecutionPolicy>(__exec), __first, __last, __s_first, __s_last, __pstl::internal::pstl_equal());
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator, class Size, class T, class _BinaryPredicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 search_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, Size __count, const T& __value, _BinaryPredicate __pred) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_search_n(__first, __last, __count, __value, __pred,
                                       internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
                                       internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 search_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Size __count, const _Tp& __value) {
     return std::search_n(__exec, __first, __last, __count, __value, std::equal_to<typename iterator_traits<_ForwardIterator>::value_type>());
 }
@@ -216,9 +216,9 @@ search_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator _
 // [alg.copy]
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
 copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result) {
-    using namespace pstl;
+    using namespace __pstl;
     const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec);
 
     return internal::pattern_walk2_brick(__first, __last, __result, [__is_vector](_ForwardIterator1 __begin, _ForwardIterator1 __end, _ForwardIterator2 __res){
@@ -227,9 +227,9 @@ copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __l
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _Size, class _ForwardIterator2>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
 copy_n(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _Size __n, _ForwardIterator2 __result) {
-    using namespace pstl;
+    using namespace __pstl;
     const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec);
 
     return internal::pattern_walk2_brick_n(__first, __n, __result, [__is_vector](_ForwardIterator1 __begin, _Size __sz, _ForwardIterator2 __res){
@@ -238,11 +238,11 @@ copy_n(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _Size __n, _Forward
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Predicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
 copy_if(_ExecutionPolicy&& __exec,
         _ForwardIterator1 __first, _ForwardIterator1 __last,
         _ForwardIterator2 __result, _Predicate __pred) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_copy_if(__first, __last, __result, __pred,
                                      internal::is_vectorization_preferred<_ExecutionPolicy,_ForwardIterator1,_ForwardIterator2>(__exec),
                                      internal::is_parallelization_preferred<_ExecutionPolicy,_ForwardIterator1,_ForwardIterator2>(__exec));
@@ -251,9 +251,9 @@ copy_if(_ExecutionPolicy&& __exec,
 // [alg.swap]
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
 swap_ranges(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_swap_ranges(__first1, __last1, __first2,
                                          internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
                                          internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
@@ -262,11 +262,11 @@ swap_ranges(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardItera
 // [alg.transform]
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _UnaryOperation>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
 transform( _ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, _UnaryOperation __op ) {
     typedef typename iterator_traits<_ForwardIterator1>::value_type _InputType;
     typedef typename iterator_traits<_ForwardIterator2>::reference _OutputType;
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_walk2(__first, __last, __result,
         [__op](_InputType __x, _OutputType __y ) mutable { __y = __op(__x);},
                                    internal::is_vectorization_preferred<_ExecutionPolicy,_ForwardIterator1,_ForwardIterator2>(__exec),
@@ -274,13 +274,13 @@ transform( _ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterato
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator, class _BinaryOperation>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator>
 transform( _ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator __result,
            _BinaryOperation __op ) {
     typedef typename iterator_traits<_ForwardIterator1>::value_type _Input1Type;
     typedef typename iterator_traits<_ForwardIterator2>::value_type _Input2Type;
     typedef typename iterator_traits<_ForwardIterator>::reference _OutputType;
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_walk3(__first1, __last1, __first2, __result, [__op]( _Input1Type x, _Input2Type y, _OutputType z ) mutable { z = __op(x,y); },
                                    internal::is_vectorization_preferred<_ExecutionPolicy,_ForwardIterator1,_ForwardIterator2,_ForwardIterator>(__exec),
                                    internal::is_parallelization_preferred<_ExecutionPolicy,_ForwardIterator1,_ForwardIterator2,_ForwardIterator>(__exec));
@@ -289,9 +289,9 @@ transform( _ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterat
 // [alg.replace]
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate, class _Tp>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
 replace_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred, const _Tp& __new_value) {
-    using namespace pstl;
+    using namespace __pstl;
     typedef typename iterator_traits<_ForwardIterator>::reference _ElementType;
     internal::pattern_walk1(__first, __last, [&__pred, &__new_value] (_ElementType __elem) {
                   if (__pred(__elem)) {
@@ -303,18 +303,18 @@ replace_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _Tp>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
 replace(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __old_value, const _Tp& __new_value) {
-    std::replace_if(__exec, __first, __last, pstl::internal::equal_value<_Tp>(__old_value), __new_value);
+    std::replace_if(__exec, __first, __last, __pstl::internal::equal_value<_Tp>(__old_value), __new_value);
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _UnaryPredicate, class _Tp>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
 replace_copy_if(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, _UnaryPredicate __pred,
                 const _Tp& __new_value) {
     typedef typename iterator_traits<_ForwardIterator1>::value_type _InputType;
     typedef typename iterator_traits<_ForwardIterator2>::reference _OutputType;
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_walk2(__first, __last, __result,
         [__pred, &__new_value](_InputType __x, _OutputType __y) mutable { __y = __pred(__x) ? __new_value : __x; },
                                    internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
@@ -322,30 +322,30 @@ replace_copy_if(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIt
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
 replace_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result,
              const _Tp& __old_value, const _Tp& __new_value) {
-    return std::replace_copy_if(__exec, __first, __last, __result, pstl::internal::equal_value<_Tp>(__old_value), __new_value);
+    return std::replace_copy_if(__exec, __first, __last, __result, __pstl::internal::equal_value<_Tp>(__old_value), __new_value);
 }
 
 // [alg.fill]
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Tp>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
 fill( _ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value ) {
-    using namespace pstl;
+    using namespace __pstl;
     internal::pattern_fill(__first, __last, __value,
                            internal::is_parallelization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec),
                            internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
 }
 
 template< class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 fill_n( _ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __count, const _Tp& __value ) {
     if(__count <= 0)
         return __first;
 
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_fill_n(__first, __count, __value,
                                     internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
                                     internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
@@ -353,21 +353,21 @@ fill_n( _ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __count, cons
 
 // [alg.generate]
 template< class _ExecutionPolicy, class _ForwardIterator, class _Generator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
 generate( _ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Generator __g ) {
-    using namespace pstl;
+    using namespace __pstl;
     internal::pattern_generate(__first, __last, __g,
                                internal::is_parallelization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec),
                                internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
 }
 
 template< class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Generator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 generate_n( _ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __count, _Generator __g ) {
     if(__count <= 0)
         return __first;
 
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_generate_n(__first, __count, __g,
                                         internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
                                         internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
@@ -376,79 +376,79 @@ generate_n( _ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __count, 
 // [alg.remove]
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Predicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
 remove_copy_if(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, _Predicate __pred) {
-    return std::copy_if( __exec, __first, __last, __result, pstl::internal::not_pred<_Predicate>(__pred));
+    return std::copy_if( __exec, __first, __last, __result, __pstl::internal::not_pred<_Predicate>(__pred));
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
 remove_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, const _Tp& __value) {
-    return std::copy_if( __exec, __first, __last, __result, pstl::internal::not_equal_value<_Tp>(__value));
+    return std::copy_if( __exec, __first, __last, __result, __pstl::internal::not_equal_value<_Tp>(__value));
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 remove_if(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_remove_if(__first, __last, __pred,
                                        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
                                        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _Tp>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 remove(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value) {
-    return std::remove_if(__exec, __first, __last, pstl::internal::equal_value<_Tp>(__value));
+    return std::remove_if(__exec, __first, __last, __pstl::internal::equal_value<_Tp>(__value));
 }
 
 // [alg.unique]
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _BinaryPredicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 unique(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _BinaryPredicate __pred) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_unique(__first, __last, __pred,
                                     internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
                                     internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 unique(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last) {
-    return std::unique(__exec, __first, __last, pstl::internal::pstl_equal());
+    return std::unique(__exec, __first, __last, __pstl::internal::pstl_equal());
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
 unique_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, _BinaryPredicate __pred) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_unique_copy(__first, __last, __result, __pred,
                                          internal::is_vectorization_preferred<_ExecutionPolicy,_ForwardIterator1,_ForwardIterator2>(__exec),
                                          internal::is_parallelization_preferred<_ExecutionPolicy,_ForwardIterator1,_ForwardIterator2>(__exec));
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
 unique_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result) {
-    return std::unique_copy( __exec, __first, __last, __result, pstl::internal::pstl_equal() );
+    return std::unique_copy( __exec, __first, __last, __result, __pstl::internal::pstl_equal() );
 }
 
 // [alg.reverse]
 
 template<class _ExecutionPolicy, class _BidirectionalIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
 reverse(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __last) {
-    using namespace pstl;
+    using namespace __pstl;
     internal::pattern_reverse(__first, __last,
                               internal::is_vectorization_preferred<_ExecutionPolicy, _BidirectionalIterator>(__exec),
                               internal::is_parallelization_preferred<_ExecutionPolicy, _BidirectionalIterator>(__exec));
 }
 
 template<class _ExecutionPolicy, class _BidirectionalIterator, class _ForwardIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 reverse_copy(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __last, _ForwardIterator __d_first) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_reverse_copy(__first, __last, __d_first,
                                           internal::is_vectorization_preferred<_ExecutionPolicy, _BidirectionalIterator, _ForwardIterator>(__exec),
                                           internal::is_parallelization_preferred<_ExecutionPolicy, _BidirectionalIterator, _ForwardIterator>(__exec));
@@ -457,18 +457,18 @@ reverse_copy(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _Bidirec
 // [alg.rotate]
 
 template<class _ExecutionPolicy, class _ForwardIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 rotate(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __middle, _ForwardIterator __last) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_rotate(__first, __middle, __last,
                                     internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
                                     internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
 rotate_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __middle, _ForwardIterator1 __last, _ForwardIterator2 __result) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_rotate_copy(__first, __middle, __last, __result,
                                          internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
                                          internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
@@ -477,37 +477,37 @@ rotate_copy(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterat
 // [alg.partitions]
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
 is_partitioned(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_is_partitioned(__first, __last, __pred,
                                             internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
                                             internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _UnaryPredicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 partition(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _UnaryPredicate __pred) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_partition(__first, __last, __pred,
                                        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
                                        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
 }
 
 template<class _ExecutionPolicy, class BidirectionalIterator, class _UnaryPredicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, BidirectionalIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, BidirectionalIterator>
 stable_partition(_ExecutionPolicy&& __exec, BidirectionalIterator __first, BidirectionalIterator __last, _UnaryPredicate __pred) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_stable_partition(__first, __last, __pred,
                                               internal::is_vectorization_preferred<_ExecutionPolicy, BidirectionalIterator>(__exec),
                                               internal::is_parallelization_preferred<_ExecutionPolicy, BidirectionalIterator>(__exec));
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _ForwardIterator1, class _ForwardIterator2, class _UnaryPredicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
 partition_copy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _ForwardIterator1 __out_true, _ForwardIterator2 __out_false,
                _UnaryPredicate __pred) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_partition_copy(__first, __last, __out_true, __out_false, __pred,
                                             internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator, _ForwardIterator1, _ForwardIterator2>(__exec),
                                             internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator, _ForwardIterator1, _ForwardIterator2>(__exec));
@@ -516,10 +516,10 @@ partition_copy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIter
 // [alg.sort]
 
 template<class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
 sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp) {
     typedef typename iterator_traits<_RandomAccessIterator>::value_type _InputType;
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_sort(__first, __last, __comp,
                                   internal::is_vectorization_preferred<_ExecutionPolicy,_RandomAccessIterator>(__exec),
                                   internal::is_parallelization_preferred<_ExecutionPolicy,_RandomAccessIterator>(__exec),
@@ -527,56 +527,56 @@ sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIter
 }
 
 template<class _ExecutionPolicy, class _RandomAccessIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
 sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last) {
-    typedef typename iterator_traits<_RandomAccessIterator>::value_type _InputType;
+    typedef typename std::iterator_traits<_RandomAccessIterator>::value_type _InputType;
     std::sort(__exec, __first, __last, std::less<_InputType>());
 }
 
 // [stable.sort]
 
 template<class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
 stable_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_stable_sort(__first, __last, __comp,
                                          internal::is_vectorization_preferred<_ExecutionPolicy,_RandomAccessIterator>(__exec),
                                          internal::is_parallelization_preferred<_ExecutionPolicy,_RandomAccessIterator>(__exec));
 }
 
 template<class _ExecutionPolicy, class _RandomAccessIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
 stable_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last) {
-    typedef typename iterator_traits<_RandomAccessIterator>::value_type _InputType;
+    typedef typename std::iterator_traits<_RandomAccessIterator>::value_type _InputType;
     std::stable_sort(__exec, __first, __last, std::less<_InputType>());
 }
 
 // [mismatch]
 
 template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
 mismatch(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
          _BinaryPredicate __pred) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_mismatch(__first1, __last1, __first2, __last2, __pred,
                                       internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
                                       internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
 }
 
 template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
 mismatch(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _BinaryPredicate __pred) {
     return std::mismatch(__exec, __first1, __last1, __first2, std::next(__first2, std::distance(__first1, __last1)), __pred);
 }
 
 template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2 >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
 mismatch(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2) {
-    return std::mismatch(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, pstl::internal::pstl_equal());
+    return std::mismatch(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __pstl::internal::pstl_equal());
 }
 
 template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2 >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator1, _ForwardIterator2>>
 mismatch(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2) {
     return std::mismatch(__exec, __first1, __last1, __first2, std::next(__first2, std::distance(__first1, __last1)));
 }
@@ -584,9 +584,9 @@ mismatch(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator
 // [alg.equal]
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
 equal(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _BinaryPredicate __p) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_equal(__first1, __last1, __first2, __p,
                                    internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1>(__exec),
                                    internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1>(__exec)
@@ -594,13 +594,13 @@ equal(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 _
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
 equal(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2) {
-    return std::equal(__exec, __first1, __last1, __first2, pstl::internal::pstl_equal());
+    return std::equal(__exec, __first1, __last1, __first2, __pstl::internal::pstl_equal());
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
 equal(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
       _BinaryPredicate __p) {
     if ( std::distance(__first1, __last1) == std::distance(__first2, __last2) )
@@ -610,16 +610,16 @@ equal(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 _
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
 equal(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2) {
-    return std::equal(__first1, __last1, __first2, pstl::internal::pstl_equal());
+    return std::equal(__first1, __last1, __first2, __pstl::internal::pstl_equal());
 }
 
 // [alg.move]
 template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2 >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
 move(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __d_first) {
-    using namespace pstl;
+    using namespace __pstl;
     const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec);
 
     return internal::pattern_walk2_brick(__first, __last, __d_first, [__is_vector](_ForwardIterator1 __begin, _ForwardIterator1 __end, _ForwardIterator2 __res) {
@@ -630,16 +630,16 @@ move(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __l
 // [partial.sort]
 
 template<class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
 partial_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __middle, _RandomAccessIterator __last, _Compare __comp) {
-    using namespace pstl;
+    using namespace __pstl;
     internal::pattern_partial_sort(__first, __middle, __last, __comp,
                                    internal::is_vectorization_preferred<_ExecutionPolicy, _RandomAccessIterator>(__exec),
                                    internal::is_parallelization_preferred<_ExecutionPolicy, _RandomAccessIterator>(__exec));
 }
 
 template<class _ExecutionPolicy, class _RandomAccessIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
 partial_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __middle, _RandomAccessIterator __last) {
     typedef typename iterator_traits<_RandomAccessIterator>::value_type _InputType;
     std::partial_sort(__exec, __first, __middle, __last, std::less<_InputType>());
@@ -648,280 +648,284 @@ partial_sort(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAc
 // [partial.sort.copy]
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _RandomAccessIterator, class _Compare>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator>
 partial_sort_copy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last,
                   _RandomAccessIterator __d_first, _RandomAccessIterator __d_last,
                   _Compare __comp) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_partial_sort_copy(__first, __last, __d_first, __d_last, __comp,
                                                internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator, _RandomAccessIterator>(__exec),
                                                internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator, _RandomAccessIterator>(__exec));
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _RandomAccessIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator>
 partial_sort_copy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last,
                   _RandomAccessIterator __d_first, _RandomAccessIterator __d_last) {
-    return std::partial_sort_copy(std::forward<_ExecutionPolicy>(__exec), __first, __last, __d_first, __d_last, pstl::internal::pstl_less());
+    return std::partial_sort_copy(std::forward<_ExecutionPolicy>(__exec), __first, __last, __d_first, __d_last, __pstl::internal::pstl_less());
 }
 
 // [is.sorted]
 template<class _ExecutionPolicy, class _ForwardIterator, class _Compare>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 is_sorted_until(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Compare __comp) {
-    using namespace pstl;
-    const _ForwardIterator __res = internal::pattern_adjacent_find(__first, __last, pstl::internal::reorder_pred<_Compare>(__comp),
+    using namespace __pstl;
+    const _ForwardIterator __res = internal::pattern_adjacent_find(__first, __last, __pstl::internal::reorder_pred<_Compare>(__comp),
                                                                    internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
                                                                    internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec), /*first_semantic*/ false);
     return __res == __last ? __last : std::next(__res);
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 is_sorted_until(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last) {
-    typedef typename iterator_traits<_ForwardIterator>::value_type _InputType;
+    typedef typename std::iterator_traits<_ForwardIterator>::value_type _InputType;
     return is_sorted_until(__exec, __first, __last, std::less<_InputType>());
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _Compare>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
 is_sorted(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Compare __comp) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_adjacent_find(__first, __last, internal::reorder_pred<_Compare>(__comp),
                                            internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
                                            internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec), /*or_semantic*/ true) == __last;
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
 is_sorted(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last) {
-    typedef typename iterator_traits<_ForwardIterator>::value_type _InputType;
+    typedef typename std::iterator_traits<_ForwardIterator>::value_type _InputType;
     return std::is_sorted(__exec, __first, __last, std::less<_InputType>());
 }
 
 // [alg.nth.element]
 
 template<class _ExecutionPolicy, class _RandomAccessIterator, class _Compare>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
 nth_element(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __nth, _RandomAccessIterator __last, _Compare __comp) {
-    using namespace pstl;
+    using namespace __pstl;
     internal::pattern_nth_element(__first, __nth, __last, __comp,
                                   internal::is_vectorization_preferred<_ExecutionPolicy, _RandomAccessIterator>(__exec),
                                   internal::is_parallelization_preferred<_ExecutionPolicy, _RandomAccessIterator>(__exec));
 }
 
 template<class _ExecutionPolicy, class _RandomAccessIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
 nth_element(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __nth, _RandomAccessIterator __last) {
-    typedef typename iterator_traits<_RandomAccessIterator>::value_type _InputType;
+    typedef typename std::iterator_traits<_RandomAccessIterator>::value_type _InputType;
     std::nth_element(__exec, __first, __nth, __last, std::less<_InputType>());
 }
 
 // [alg.merge]
 template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator, class _Compare>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 merge(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
       _ForwardIterator __d_first, _Compare __comp) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_merge(__first1, __last1, __first2, __last2, __d_first, __comp,
                                    internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2, _ForwardIterator>(__exec),
                                    internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2, _ForwardIterator>(__exec));
 }
 
 template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 merge(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
       _ForwardIterator __d_first) {
-    return std::merge(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __d_first, pstl::internal::pstl_less());
+    return std::merge(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __d_first, __pstl::internal::pstl_less());
 }
 
 template< class _ExecutionPolicy, class _BidirectionalIterator, class _Compare>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
 inplace_merge(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __middle, _BidirectionalIterator __last, _Compare __comp) {
-    using namespace pstl;
+    using namespace __pstl;
     internal::pattern_inplace_merge(__first, __middle, __last, __comp,
                                     internal::is_vectorization_preferred<_ExecutionPolicy, _BidirectionalIterator>(__exec),
                                     internal::is_parallelization_preferred<_ExecutionPolicy, _BidirectionalIterator>(__exec));
 }
 
 template< class _ExecutionPolicy, class _BidirectionalIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
 inplace_merge(_ExecutionPolicy&& __exec, _BidirectionalIterator __first, _BidirectionalIterator __middle, _BidirectionalIterator __last) {
-    typedef typename iterator_traits<_BidirectionalIterator>::value_type _InputType;
+    typedef typename std::iterator_traits<_BidirectionalIterator>::value_type _InputType;
     std::inplace_merge(__exec, __first, __middle, __last, std::less<_InputType>());
 }
 
 // [includes]
 
 template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Compare>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
 includes(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
          _Compare __comp) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_includes(__first1, __last1, __first2, __last2, __comp,
                                       internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
                                       internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
 }
 
 template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
 includes(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2) {
-    return includes(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, pstl::internal::pstl_less());}
+    return std::includes(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __pstl::internal::pstl_less());}
 
 // [set.union]
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator, class _Compare>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 set_union(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
           _ForwardIterator __result, _Compare __comp) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_set_union(__first1, __last1, __first2, __last2, __result, __comp,
                                        internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2, _ForwardIterator>(__exec),
                                        internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2, _ForwardIterator>(__exec));
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 set_union(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
     _ForwardIterator2 __last2, _ForwardIterator __result) {
-    return set_union(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __result, pstl::internal::pstl_less());
+    return std::set_union(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __result,
+                          __pstl::internal::pstl_less());
 }
 
 // [set.intersection]
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator, class _Compare>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 set_intersection(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
                  _ForwardIterator __result, _Compare __comp) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_set_intersection(__first1, __last1, __first2, __last2, __result, __comp,
                                               internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2, _ForwardIterator>(__exec),
                                               internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2, _ForwardIterator>(__exec));
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 set_intersection(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
                  _ForwardIterator __result) {
-    return std::set_intersection(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __result, pstl::internal::pstl_less());
+    return std::set_intersection(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __result,
+                                 __pstl::internal::pstl_less());
 }
 
 // [set.difference]
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator, class _Compare>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 set_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
                _ForwardIterator __result, _Compare __comp) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_set_difference(__first1, __last1, __first2, __last2, __result, __comp,
                                             internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2, _ForwardIterator>(__exec),
                                             internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2, _ForwardIterator>(__exec));
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 set_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
                _ForwardIterator __result) {
-    return std::set_difference(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __result, pstl::internal::pstl_less());
+    return std::set_difference(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __result,
+                               __pstl::internal::pstl_less());
 }
 
 // [set.symmetric.difference]
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator, class _Compare>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 set_symmetric_difference(_ExecutionPolicy&& __exec,
                          _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
                          _ForwardIterator __result, _Compare __comp) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_set_symmetric_difference(__first1, __last1, __first2, __last2, __result, __comp,
                                                       internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2, _ForwardIterator>(__exec),
                                                       internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2, _ForwardIterator>(__exec));
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _ForwardIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 set_symmetric_difference(_ExecutionPolicy&& __exec,
                          _ForwardIterator1 __first1, _ForwardIterator1 __last1,
                          _ForwardIterator2 __first2, _ForwardIterator2 __last2,
                          _ForwardIterator __result) {
-    return std::set_symmetric_difference(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __result, pstl::internal::pstl_less());
+    return std::set_symmetric_difference(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __result,
+                                         __pstl::internal::pstl_less());
 }
 
 // [is.heap]
 template< class _ExecutionPolicy, class _RandomAccessIterator, class _Compare >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator>
 is_heap_until(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_is_heap_until(__first, __last, __comp,
                                            internal::is_vectorization_preferred<_ExecutionPolicy, _RandomAccessIterator>(__exec),
                                            internal::is_parallelization_preferred<_ExecutionPolicy, _RandomAccessIterator>(__exec));
 }
 
 template< class _ExecutionPolicy, class _RandomAccessIterator >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _RandomAccessIterator>
 is_heap_until(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last) {
-    typedef typename iterator_traits<_RandomAccessIterator>::value_type _InputType;
+    typedef typename std::iterator_traits<_RandomAccessIterator>::value_type _InputType;
     return std::is_heap_until(__exec, __first, __last, std::less<_InputType>());
 }
 
 template< class _ExecutionPolicy, class _RandomAccessIterator, class _Compare >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
 is_heap(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last, _Compare __comp) {
     return std::is_heap_until(__exec, __first, __last, __comp) == __last;
 }
 
 template< class _ExecutionPolicy, class _RandomAccessIterator >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
 is_heap(_ExecutionPolicy&& __exec, _RandomAccessIterator __first, _RandomAccessIterator __last) {
-    typedef typename iterator_traits<_RandomAccessIterator>::value_type _InputType;
+    typedef typename std::iterator_traits<_RandomAccessIterator>::value_type _InputType;
     return std::is_heap(__exec, __first, __last, std::less<_InputType>());
 }
 
 // [alg.min.max]
 
 template< class _ExecutionPolicy, class _ForwardIterator, class _Compare >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 min_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Compare __comp) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_min_element(__first, __last, __comp,
                                          internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
                                          internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
 }
 
 template< class _ExecutionPolicy, class _ForwardIterator >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 min_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last) {
-    typedef typename iterator_traits<_ForwardIterator>::value_type _InputType;
+    typedef typename std::iterator_traits<_ForwardIterator>::value_type _InputType;
     return std::min_element(__exec, __first, __last, std::less<_InputType>());
 }
 
 template< class _ExecutionPolicy, class _ForwardIterator, class _Compare >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 max_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Compare __comp) {
-    using namespace pstl;
-    return internal::pattern_min_element(__first, __last, pstl::internal::reorder_pred<_Compare>(__comp),
+    using namespace __pstl;
+    return internal::pattern_min_element(__first, __last, __pstl::internal::reorder_pred<_Compare>(__comp),
                                          internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
                                          internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
 }
 
 template< class _ExecutionPolicy, class _ForwardIterator >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 max_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last) {
-    typedef typename iterator_traits<_ForwardIterator>::value_type _InputType;
-    return std::min_element(__exec, __first, __last, pstl::internal::reorder_pred<std::less<_InputType>>(std::less<_InputType>()));
+    typedef typename std::iterator_traits<_ForwardIterator>::value_type _InputType;
+    return std::min_element(__exec, __first, __last, __pstl::internal::reorder_pred<std::less<_InputType>>(std::less<_InputType>()));
 }
 
 template< class _ExecutionPolicy, class _ForwardIterator, class _Compare >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator, _ForwardIterator>>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator, _ForwardIterator>>
 minmax_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Compare __comp) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_minmax_element(__first, __last, __comp,
                                             internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec),
                                             internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec));
 }
 
 template< class _ExecutionPolicy, class _ForwardIterator >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator, _ForwardIterator>>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, std::pair<_ForwardIterator, _ForwardIterator>>
 minmax_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last) {
     typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
     return std::minmax_element(__exec, __first, __last, std::less<_ValueType>());
@@ -930,21 +934,21 @@ minmax_element(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIter
 // [alg.lex.comparison]
 
 template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Compare >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
 lexicographical_compare(_ExecutionPolicy&& __exec,
                         _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2,
                         _Compare __comp) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_lexicographical_compare(__first1, __last1, __first2, __last2, __comp,
                                                      internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
                                                      internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
 }
 
 template< class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2 >
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, bool>
 lexicographical_compare(_ExecutionPolicy&& __exec,
                         _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _ForwardIterator2 __last2) {
-    return std::lexicographical_compare(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, pstl::internal::pstl_less());
+    return std::lexicographical_compare(std::forward<_ExecutionPolicy>(__exec), __first1, __last1, __first2, __last2, __pstl::internal::pstl_less());
 }
 
 } // namespace std

--- a/include/pstl/internal/glue_execution_defs.h
+++ b/include/pstl/internal/glue_execution_defs.h
@@ -29,33 +29,33 @@
 
 namespace std {
     // Type trait
-    using pstl::execution::is_execution_policy;
+    using __pstl::execution::is_execution_policy;
 #if __PSTL_CPP14_VARIABLE_TEMPLATES_PRESENT
 #if __INTEL_COMPILER
     template<class T> constexpr bool is_execution_policy_v = is_execution_policy<T>::value;
 #else
-    using pstl::execution::is_execution_policy_v;
+    using __pstl::execution::is_execution_policy_v;
 #endif
 #endif
 
     namespace execution {
         // Standard C++ policy classes
-        using pstl::execution::sequenced_policy;
+        using __pstl::execution::sequenced_policy;
 #if __PSTL_USE_PAR_POLICIES
-        using pstl::execution::parallel_policy;
-        using pstl::execution::parallel_unsequenced_policy;
+        using __pstl::execution::parallel_policy;
+        using __pstl::execution::parallel_unsequenced_policy;
 #endif
         // Standard predefined policy instances
-        using pstl::execution::seq;
+        using __pstl::execution::seq;
 #if __PSTL_USE_PAR_POLICIES
-        using pstl::execution::par;
-        using pstl::execution::par_unseq;
+        using __pstl::execution::par;
+        using __pstl::execution::par_unseq;
 #endif
         // Implementation-defined names
         // Unsequenced policy is not yet standard, but for consistency
         // we include it into namespace std::execution as well
-        using pstl::execution::unseq;
-        using pstl::execution::unsequenced_policy;
+        using __pstl::execution::unseq;
+        using __pstl::execution::unsequenced_policy;
     }
 }
 

--- a/include/pstl/internal/glue_memory_defs.h
+++ b/include/pstl/internal/glue_memory_defs.h
@@ -27,63 +27,63 @@ namespace std {
 
 // [uninitialized.copy]
 
-template<class ExecutionPolicy, class InputIterator, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-uninitialized_copy(ExecutionPolicy&& exec, InputIterator first, InputIterator last, ForwardIterator result);
+template<class _ExecutionPolicy, class _InputIterator, class _ForwardIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+uninitialized_copy(_ExecutionPolicy&& __exec, _InputIterator __first, _InputIterator __last, _ForwardIterator __result);
 
-template<class ExecutionPolicy, class InputIterator, class Size, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-uninitialized_copy_n(ExecutionPolicy&& exec, InputIterator first, Size n, ForwardIterator result);
+template<class _ExecutionPolicy, class _InputIterator, class _Size, class _ForwardIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+uninitialized_copy_n(_ExecutionPolicy&& __exec, _InputIterator __first, _Size __n, _ForwardIterator __result);
 
 // [uninitialized.move]
 
-template<class ExecutionPolicy, class InputIterator, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-uninitialized_move(ExecutionPolicy&& exec, InputIterator first, InputIterator last, ForwardIterator result);
+template<class _ExecutionPolicy, class _InputIterator, class _ForwardIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+uninitialized_move(_ExecutionPolicy&& __exec, _InputIterator __first, _InputIterator __last, _ForwardIterator __result);
 
-template<class ExecutionPolicy, class InputIterator, class Size, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-uninitialized_move_n(ExecutionPolicy&& exec, InputIterator first, Size n, ForwardIterator result);
+template<class _ExecutionPolicy, class _InputIterator, class _Size, class _ForwardIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+uninitialized_move_n(_ExecutionPolicy&& __exec, _InputIterator __first, _Size __n, _ForwardIterator __result);
 
 // [uninitialized.fill]
 
-template<class ExecutionPolicy, class ForwardIterator, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-uninitialized_fill(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, const T& value);
+template<class _ExecutionPolicy, class _ForwardIterator, class _Tp>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+uninitialized_fill(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value);
 
-template<class ExecutionPolicy, class ForwardIterator, class Size, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-uninitialized_fill_n(ExecutionPolicy&& exec, ForwardIterator first, Size n, const T& value);
+template<class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+uninitialized_fill_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size n, const _Tp& __value);
 
 // [specialized.destroy]
 
-template <class ExecutionPolicy, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-destroy(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last);
+template <class _ExecutionPolicy, class _ForwardIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+destroy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last);
 
-template <class ExecutionPolicy, class ForwardIterator, class Size>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-destroy_n(ExecutionPolicy&& exec, ForwardIterator first, Size n);
+template <class _ExecutionPolicy, class _ForwardIterator, class _Size>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+destroy_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n);
 
 // [uninitialized.construct.default]
 
-template <class ExecutionPolicy, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-uninitialized_default_construct(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last);
+template <class _ExecutionPolicy, class _ForwardIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+uninitialized_default_construct(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last);
 
-template <class ExecutionPolicy, class ForwardIterator, class Size>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-uninitialized_default_construct_n(ExecutionPolicy&& exec, ForwardIterator first, Size n);
+template <class _ExecutionPolicy, class _ForwardIterator, class _Size>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+uninitialized_default_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n);
 
 // [uninitialized.construct.value]
 
-template <class ExecutionPolicy, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-uninitialized_value_construct(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last);
+template <class _ExecutionPolicy, class _ForwardIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+uninitialized_value_construct(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last);
 
-template <class ExecutionPolicy, class ForwardIterator, class Size>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-uninitialized_value_construct_n(ExecutionPolicy&& exec, ForwardIterator first, Size n);
+template <class _ExecutionPolicy, class _ForwardIterator, class _Size>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+uninitialized_value_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n);
 
 } //  namespace std
 #endif /* __PSTL_glue_memory_defs_H */

--- a/include/pstl/internal/glue_memory_defs.h
+++ b/include/pstl/internal/glue_memory_defs.h
@@ -28,61 +28,61 @@ namespace std {
 // [uninitialized.copy]
 
 template<class _ExecutionPolicy, class _InputIterator, class _ForwardIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 uninitialized_copy(_ExecutionPolicy&& __exec, _InputIterator __first, _InputIterator __last, _ForwardIterator __result);
 
 template<class _ExecutionPolicy, class _InputIterator, class _Size, class _ForwardIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 uninitialized_copy_n(_ExecutionPolicy&& __exec, _InputIterator __first, _Size __n, _ForwardIterator __result);
 
 // [uninitialized.move]
 
 template<class _ExecutionPolicy, class _InputIterator, class _ForwardIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 uninitialized_move(_ExecutionPolicy&& __exec, _InputIterator __first, _InputIterator __last, _ForwardIterator __result);
 
 template<class _ExecutionPolicy, class _InputIterator, class _Size, class _ForwardIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 uninitialized_move_n(_ExecutionPolicy&& __exec, _InputIterator __first, _Size __n, _ForwardIterator __result);
 
 // [uninitialized.fill]
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _Tp>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
 uninitialized_fill(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value);
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
-uninitialized_fill_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size n, const _Tp& __value);
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+uninitialized_fill_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n, const _Tp& __value);
 
 // [specialized.destroy]
 
 template <class _ExecutionPolicy, class _ForwardIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
 destroy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last);
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Size>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 destroy_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n);
 
 // [uninitialized.construct.default]
 
 template <class _ExecutionPolicy, class _ForwardIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
 uninitialized_default_construct(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last);
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Size>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 uninitialized_default_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n);
 
 // [uninitialized.construct.value]
 
 template <class _ExecutionPolicy, class _ForwardIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
 uninitialized_value_construct(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last);
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Size>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 uninitialized_value_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n);
 
 } //  namespace std

--- a/include/pstl/internal/glue_memory_impl.h
+++ b/include/pstl/internal/glue_memory_impl.h
@@ -26,211 +26,220 @@
 
 namespace std {
 
-template<class ExecutionPolicy, class InputIterator, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-uninitialized_copy(ExecutionPolicy&& exec, InputIterator first, InputIterator last, ForwardIterator result) {
-    typedef typename iterator_traits<InputIterator>::value_type value_type1;
-    typedef typename iterator_traits<ForwardIterator>::value_type value_type2;
-    using namespace pstl::internal;
+template<class _ExecutionPolicy, class _InputIterator, class _ForwardIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+uninitialized_copy(_ExecutionPolicy&& __exec, _InputIterator __first, _InputIterator __last, _ForwardIterator __result) {
+    typedef typename iterator_traits<_InputIterator>::value_type _ValueType1;
+    typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType2;
+    using namespace pstl;
 
-    const auto is_parallel = is_parallelization_preferred<ExecutionPolicy, InputIterator, ForwardIterator>(exec);
-    const auto is_vector = is_vectorization_preferred<ExecutionPolicy, InputIterator, ForwardIterator>(exec);
+    const auto __is_parallel = internal::is_parallelization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(__exec);
+    const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(__exec);
 
-    return invoke_if_else(std::integral_constant<bool, std::is_trivial<value_type1>::value && std::is_trivial<value_type2>::value>(),
-        [&]() { return pattern_walk2_brick(first, last, result, [is_vector](InputIterator begin, InputIterator end, ForwardIterator res)
-            { return brick_copy(begin, end, res, is_vector); }, is_parallel); },
-        [&]() { return pattern_it_walk2(first, last, result, [](InputIterator it1, ForwardIterator it2)
-            { ::new (reduce_to_ptr(it2)) value_type2(*it1); }, is_vector, is_parallel); }
+    return internal::invoke_if_else(std::integral_constant<bool, std::is_trivial<_ValueType1>::value && std::is_trivial<_ValueType2>::value>(),
+                                    [&]() { return internal::pattern_walk2_brick(__first, __last, __result,
+                                                                                [__is_vector](_InputIterator __begin, _InputIterator __end, _ForwardIterator __res)
+                                                                                { return internal::brick_copy(__begin, __end, __res, __is_vector); }, __is_parallel); },
+                                    [&]() { return internal::pattern_it_walk2(__first, __last, __result, [](_InputIterator __it1, _ForwardIterator __it2)
+                                                                              { ::new (internal::reduce_to_ptr(__it2)) _ValueType2(*__it1); }, __is_vector, __is_parallel); }
     );
 }
 
-template<class ExecutionPolicy, class InputIterator, class Size, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-uninitialized_copy_n(ExecutionPolicy&& exec, InputIterator first, Size n, ForwardIterator result) {
-    typedef typename iterator_traits<InputIterator>::value_type value_type1;
-    typedef typename iterator_traits<ForwardIterator>::value_type value_type2;
-    using namespace pstl::internal;
+template<class _ExecutionPolicy, class _InputIterator, class _Size, class _ForwardIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+uninitialized_copy_n(_ExecutionPolicy&& __exec, _InputIterator __first, _Size __n, _ForwardIterator __result) {
+    typedef typename iterator_traits<_InputIterator>::value_type _ValueType1;
+    typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType2;
+    using namespace pstl;
 
-    const auto is_parallel = is_parallelization_preferred<ExecutionPolicy, InputIterator, ForwardIterator>(exec);
-    const auto is_vector = is_vectorization_preferred<ExecutionPolicy, InputIterator, ForwardIterator>(exec);
+    const auto __is_parallel = internal::is_parallelization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(__exec);
+    const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(__exec);
 
-    return invoke_if_else(std::integral_constant<bool, std::is_trivial<value_type1>::value && std::is_trivial<value_type2>::value>(),
-        [&]() { return pattern_walk2_brick_n(first, n, result, [is_vector](InputIterator begin, Size sz, ForwardIterator res)
-            { return brick_copy_n(begin, sz, res, is_vector); }, is_parallel); },
-        [&]() { return pattern_it_walk2_n(first, n, result, [](InputIterator it1, ForwardIterator it2)
-            { ::new (reduce_to_ptr(it2)) value_type2(*it1); }, is_vector, is_parallel); }
+    return internal::invoke_if_else(std::integral_constant<bool, std::is_trivial<_ValueType1>::value && std::is_trivial<_ValueType2>::value>(),
+                                    [&]() { return internal::pattern_walk2_brick_n(__first, __n, __result,
+                                                                                   [__is_vector](_InputIterator __begin, _Size __sz, _ForwardIterator __res)
+                                                                                   { return internal::brick_copy_n(__begin, __sz, __res, __is_vector); }, __is_parallel); },
+                                    [&]() { return internal::pattern_it_walk2_n(__first, __n, __result, [](_InputIterator __it1, _ForwardIterator __it2)
+                                                                                { ::new (internal::reduce_to_ptr(__it2)) _ValueType2(*__it1); }, __is_vector, __is_parallel); }
     );
 }
 
 // [uninitialized.move]
 
-template<class ExecutionPolicy, class InputIterator, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-uninitialized_move(ExecutionPolicy&& exec, InputIterator first, InputIterator last, ForwardIterator result) {
-    typedef typename iterator_traits<InputIterator>::value_type value_type1;
-    typedef typename iterator_traits<ForwardIterator>::value_type value_type2;
-    using namespace pstl::internal;
+template<class _ExecutionPolicy, class _InputIterator, class _ForwardIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+uninitialized_move(_ExecutionPolicy&& __exec, _InputIterator __first, _InputIterator __last, _ForwardIterator __result) {
+    typedef typename iterator_traits<_InputIterator>::value_type _ValueType1;
+    typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType2;
+    using namespace pstl;
 
-    const auto is_parallel = is_parallelization_preferred<ExecutionPolicy, InputIterator, ForwardIterator>(exec);
-    const auto is_vector = is_vectorization_preferred<ExecutionPolicy, InputIterator, ForwardIterator>(exec);
+    const auto __is_parallel = internal::is_parallelization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(__exec);
+    const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(__exec);
 
-    return invoke_if_else(std::integral_constant<bool, std::is_trivial<value_type1>::value && std::is_trivial<value_type2>::value>(),
-        [&]() { return pattern_walk2_brick(first, last, result, [is_vector](InputIterator begin, InputIterator end, ForwardIterator res)
-            { return brick_copy(begin, end, res, is_vector);}, is_parallel); },
-        [&]() { return pattern_it_walk2(first, last, result, [](InputIterator it1, ForwardIterator it2)
-            { ::new (reduce_to_ptr(it2)) value_type2(std::move(*it1)); }, is_vector, is_parallel); }
+    return internal::invoke_if_else(std::integral_constant<bool, std::is_trivial<_ValueType1>::value && std::is_trivial<_ValueType2>::value>(),
+                                    [&]() { return internal::pattern_walk2_brick(__first, __last, __result,
+                                                                                 [__is_vector](_InputIterator __begin, _InputIterator __end, _ForwardIterator __res)
+                                                                                 { return internal::brick_copy(__begin, __end, __res, __is_vector);}, __is_parallel); },
+                                    [&]() { return internal::pattern_it_walk2(__first, __last, __result, [](_InputIterator __it1, _ForwardIterator __it2)
+                                                                              { ::new (internal::reduce_to_ptr(__it2)) _ValueType2(std::move(*__it1)); }, __is_vector, __is_parallel); }
         );
 }
 
-template<class ExecutionPolicy, class InputIterator, class Size, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-uninitialized_move_n(ExecutionPolicy&& exec, InputIterator first, Size n, ForwardIterator result) {
-    typedef typename iterator_traits<InputIterator>::value_type value_type1;
-    typedef typename iterator_traits<ForwardIterator>::value_type value_type2;
-    using namespace pstl::internal;
+template<class _ExecutionPolicy, class _InputIterator, class _Size, class _ForwardIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+uninitialized_move_n(_ExecutionPolicy&& __exec, _InputIterator __first, _Size __n, _ForwardIterator __result) {
+    typedef typename iterator_traits<_InputIterator>::value_type _ValueType1;
+    typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType2;
+    using namespace pstl;
 
-    const auto is_parallel = is_parallelization_preferred<ExecutionPolicy, InputIterator, ForwardIterator>(exec);
-    const auto is_vector = is_vectorization_preferred<ExecutionPolicy, InputIterator, ForwardIterator>(exec);
+    const auto __is_parallel = internal::is_parallelization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(__exec);
+    const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(__exec);
 
-    return invoke_if_else(std::integral_constant<bool, std::is_trivial<value_type1>::value && std::is_trivial<value_type2>::value>(),
-        [&]() { return pattern_walk2_brick_n(first, n, result, [is_vector](InputIterator begin, Size sz, ForwardIterator res)
-            { return brick_copy_n(begin, sz, res, is_vector);}, is_parallel); },
-        [&]() { return pattern_it_walk2_n(first, n, result, [](InputIterator it1, ForwardIterator it2)
-            { ::new (reduce_to_ptr(it2)) value_type2(std::move(*it1)); }, is_vector, is_parallel); }
+    return internal::invoke_if_else(std::integral_constant<bool, std::is_trivial<_ValueType1>::value && std::is_trivial<_ValueType2>::value>(),
+                                    [&]() { return internal::pattern_walk2_brick_n(__first, __n, __result,
+                                                                                   [__is_vector](_InputIterator __begin, _Size __sz, _ForwardIterator __res)
+                                                                                   { return internal::brick_copy_n(__begin, __sz, __res, __is_vector);}, __is_parallel); },
+                                    [&]() { return internal::pattern_it_walk2_n(__first, __n, __result, [](_InputIterator __it1, _ForwardIterator __it2)
+                                                                                { ::new (internal::reduce_to_ptr(__it2)) _ValueType2(std::move(*__it1)); }, __is_vector, __is_parallel); }
         );
 }
 
 // [uninitialized.fill]
 
-template<class ExecutionPolicy, class ForwardIterator, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-uninitialized_fill(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, const T& value) {
-    typedef typename iterator_traits<ForwardIterator>::value_type value_type;
-    using namespace pstl::internal;
+template<class _ExecutionPolicy, class _ForwardIterator, class _Tp>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+uninitialized_fill(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value) {
+    typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
+    using namespace pstl;
 
-    const auto is_parallel = is_parallelization_preferred<ExecutionPolicy, ForwardIterator>(exec);
-    const auto is_vector = is_vectorization_preferred<ExecutionPolicy, ForwardIterator>(exec);
+    const auto __is_parallel = internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
+    const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
 
-    invoke_if_else(std::is_arithmetic<value_type>(),
-        [&]() { pattern_walk_brick(first, last, [&value, &is_vector](ForwardIterator begin, ForwardIterator end)
-            { brick_fill(begin, end, value_type(value), is_vector);}, is_parallel); },
-        [&]() { pattern_it_walk1(first, last, [&value](ForwardIterator it)
-            { ::new (reduce_to_ptr(it)) value_type(value); }, is_vector, is_parallel); }
+    internal::invoke_if_else(std::is_arithmetic<_ValueType>(),
+                             [&]() { internal::pattern_walk_brick(__first, __last,
+                                                                  [&__value, &__is_vector](_ForwardIterator __begin, _ForwardIterator __end)
+                                                                  { internal::brick_fill(__begin, __end, _ValueType(__value), __is_vector);}, __is_parallel); },
+                             [&]() { internal::pattern_it_walk1(__first, __last, [&__value](_ForwardIterator __it)
+                                                                { ::new (internal::reduce_to_ptr(__it)) _ValueType(__value); }, __is_vector, __is_parallel); }
         );
 }
 
-template<class ExecutionPolicy, class ForwardIterator, class Size, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-uninitialized_fill_n(ExecutionPolicy&& exec, ForwardIterator first, Size n, const T& value) {
-    typedef typename iterator_traits<ForwardIterator>::value_type value_type;
-    using namespace pstl::internal;
+template<class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+uninitialized_fill_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n, const _Tp& __value) {
+    typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
+    using namespace pstl;
 
-    const auto is_parallel = is_parallelization_preferred<ExecutionPolicy, ForwardIterator>(exec);
-    const auto is_vector = is_vectorization_preferred<ExecutionPolicy, ForwardIterator>(exec);
+    const auto __is_parallel = internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
+    const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
 
-    return invoke_if_else(std::is_arithmetic<value_type>(),
-        [&]() { return pattern_walk_brick_n(first, n, [&value, &is_vector](ForwardIterator begin, Size count)
-            { return brick_fill_n(begin, count, value_type(value), is_vector);}, is_parallel); },
-        [&]() { return pattern_it_walk1_n(first, n, [&value](ForwardIterator it)
-            { ::new (reduce_to_ptr(it)) value_type(value); }, is_vector, is_parallel); }
+    return internal::invoke_if_else(std::is_arithmetic<_ValueType>(),
+                                    [&]() { return internal::pattern_walk_brick_n(__first, __n,
+                                                                                  [&__value, &__is_vector](_ForwardIterator __begin, _Size __count)
+                                                                                  { return internal::brick_fill_n(__begin, __count, _ValueType(__value), __is_vector);}, __is_parallel); },
+                                    [&]() { return internal::pattern_it_walk1_n(__first, __n, [&__value](_ForwardIterator __it)
+                                                                                { ::new (internal::reduce_to_ptr(__it)) _ValueType(__value); }, __is_vector, __is_parallel); }
         );
 }
 
 // [specialized.destroy]
 
-template <class ExecutionPolicy, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-destroy(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last) {
-    typedef typename iterator_traits<ForwardIterator>::value_type value_type;
-    using namespace pstl::internal;
+template <class _ExecutionPolicy, class _ForwardIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+destroy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last) {
+    typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
+    using namespace pstl;
 
-    const auto is_parallel = is_parallelization_preferred<ExecutionPolicy, ForwardIterator>(exec);
-    const auto is_vector = is_vectorization_preferred<ExecutionPolicy, ForwardIterator>(exec);
+    const auto __is_parallel = internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
+    const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
 
-    invoke_if_not(std::is_trivially_destructible<value_type>(),
-        [&]() { pattern_it_walk1(first, last, [](ForwardIterator it){ (*it).~value_type(); }, is_vector, is_parallel); }
+    internal::invoke_if_not(std::is_trivially_destructible<_ValueType>(),
+                            [&]() { internal::pattern_it_walk1(__first, __last,
+                                                               [](_ForwardIterator __it){ (*__it).~_ValueType(); }, __is_vector, __is_parallel); }
         );
 }
 
-template <class ExecutionPolicy, class ForwardIterator, class Size>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-destroy_n(ExecutionPolicy&& exec, ForwardIterator first, Size n) {
-    typedef typename iterator_traits<ForwardIterator>::value_type value_type;
-    using namespace pstl::internal;
+template <class _ExecutionPolicy, class _ForwardIterator, class _Size>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+destroy_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n) {
+    typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
+    using namespace pstl;
 
-    const auto is_parallel = is_parallelization_preferred<ExecutionPolicy, ForwardIterator>(exec);
-    const auto is_vector = is_vectorization_preferred<ExecutionPolicy, ForwardIterator>(exec);
+    const auto __is_parallel = internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
+    const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
 
-    return invoke_if_else(std::is_trivially_destructible<value_type>(),
-        [&]() { return std::next(first, n);},
-        [&]() { return pattern_it_walk1_n(first, n, [](ForwardIterator it){ (*it).~value_type(); }, is_vector, is_parallel); }
+    return internal::invoke_if_else(std::is_trivially_destructible<_ValueType>(),
+        [&]() { return std::next(__first, __n);},
+                          [&]() { return internal::pattern_it_walk1_n(__first, __n,
+                                                                      [](_ForwardIterator __it){ (*__it).~_ValueType(); }, __is_vector, __is_parallel); }
         );
 }
 
 // [uninitialized.construct.default]
 
-template <class ExecutionPolicy, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-uninitialized_default_construct(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last) {
-    typedef typename iterator_traits<ForwardIterator>::value_type value_type;
-    using namespace pstl::internal;
+template <class _ExecutionPolicy, class _ForwardIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+uninitialized_default_construct(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last) {
+    typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
+    using namespace pstl;
 
-    const auto is_parallel = is_parallelization_preferred<ExecutionPolicy, ForwardIterator>(exec);
-    const auto is_vector = is_vectorization_preferred<ExecutionPolicy, ForwardIterator>(exec);
+    const auto __is_parallel = internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
+    const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
 
-    invoke_if_not(std::is_trivial<value_type>(),
-        [&]() { pattern_it_walk1(first, last, [](ForwardIterator it) { ::new (reduce_to_ptr(it)) value_type; }, is_vector, is_parallel); });
+    internal::invoke_if_not(std::is_trivial<_ValueType>(),
+                            [&]() { internal::pattern_it_walk1(__first, __last, [](_ForwardIterator __it) { ::new (internal::reduce_to_ptr(__it)) _ValueType; },
+                                 __is_vector, __is_parallel); });
 }
 
-template <class ExecutionPolicy, class ForwardIterator, class Size>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-uninitialized_default_construct_n(ExecutionPolicy&& exec, ForwardIterator first, Size n) {
-    typedef typename iterator_traits<ForwardIterator>::value_type value_type;
-    using namespace pstl::internal;
+template <class _ExecutionPolicy, class _ForwardIterator, class _Size>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+uninitialized_default_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n) {
+    typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
+    using namespace pstl;
 
-    const auto is_parallel = is_parallelization_preferred<ExecutionPolicy, ForwardIterator>(exec);
-    const auto is_vector = is_vectorization_preferred<ExecutionPolicy, ForwardIterator>(exec);
+    const auto __is_parallel = internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
+    const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
 
-    return invoke_if_else(std::is_trivial<value_type>(),
-        [&]() { return std::next(first, n);},
-        [&]() { return pattern_it_walk1_n(first, n, [](ForwardIterator it)
-            { ::new (reduce_to_ptr(it)) value_type; }, is_vector, is_parallel); }
+    return internal::invoke_if_else(std::is_trivial<_ValueType>(),
+        [&]() { return std::next(__first, __n);},
+                                    [&]() { return internal::pattern_it_walk1_n(__first, __n, [](_ForwardIterator __it)
+                                                                                { ::new (internal::reduce_to_ptr(__it)) _ValueType; }, __is_vector, __is_parallel); }
         );
 }
 
 // [uninitialized.construct.value]
 
-template <class ExecutionPolicy, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, void>
-uninitialized_value_construct(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last) {
-    typedef typename iterator_traits<ForwardIterator>::value_type value_type;
-    using namespace pstl::internal;
+template <class _ExecutionPolicy, class _ForwardIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+uninitialized_value_construct(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last) {
+    typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
+    using namespace pstl;
 
-    const auto is_parallel = is_parallelization_preferred<ExecutionPolicy, ForwardIterator>(exec);
-    const auto is_vector = is_vectorization_preferred<ExecutionPolicy, ForwardIterator>(exec);
+    const auto __is_parallel = internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
+    const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
 
-    invoke_if_else(std::is_trivial<value_type>(),
-        [&]() { pattern_walk_brick(first, last, [is_vector](ForwardIterator begin, ForwardIterator end)
-            { brick_fill(begin, end, value_type(), is_vector);}, is_parallel); },
-        [&]() { pattern_it_walk1(first, last, [](ForwardIterator it)
-            { ::new (reduce_to_ptr(it)) value_type(); }, is_vector, is_parallel); }
+    internal::invoke_if_else(std::is_trivial<_ValueType>(),
+                             [&]() { internal::pattern_walk_brick(__first, __last, [__is_vector](_ForwardIterator __begin, _ForwardIterator __end)
+                                                                  { internal::brick_fill(__begin, __end, _ValueType(), __is_vector);}, __is_parallel); },
+                             [&]() { internal::pattern_it_walk1(__first, __last, [](_ForwardIterator it)
+                                                                { ::new (internal::reduce_to_ptr(it)) _ValueType(); }, __is_vector, __is_parallel); }
         );
 }
 
-template <class ExecutionPolicy, class ForwardIterator, class Size>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator>
-uninitialized_value_construct_n(ExecutionPolicy&& exec, ForwardIterator first, Size n) {
-    typedef typename iterator_traits<ForwardIterator>::value_type value_type;
-    using namespace pstl::internal;
+template <class _ExecutionPolicy, class _ForwardIterator, class _Size>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+uninitialized_value_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n) {
+    typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
+    using namespace pstl;
 
-    const auto is_parallel = is_parallelization_preferred<ExecutionPolicy, ForwardIterator>(exec);
-    const auto is_vector = is_vectorization_preferred<ExecutionPolicy, ForwardIterator>(exec);
+    const auto __is_parallel = internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
+    const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
 
-    return invoke_if_else(std::is_trivial<value_type>(),
-        [&]() { return pattern_walk_brick_n(first, n, [is_vector](ForwardIterator begin, Size count)
-            { return brick_fill_n(begin, count, value_type(), is_vector);}, is_parallel); },
-        [&]() { return pattern_it_walk1_n(first, n, [](ForwardIterator it)
-            { ::new (reduce_to_ptr(it)) value_type(); }, is_vector, is_parallel); }
+    return internal::invoke_if_else(std::is_trivial<_ValueType>(),
+                                    [&]() { return internal::pattern_walk_brick_n(__first, __n, [__is_vector](_ForwardIterator __begin, _Size __count)
+                                                                                  { return internal::brick_fill_n(__begin, __count, _ValueType(), __is_vector);}, __is_parallel); },
+                                    [&]() { return internal::pattern_it_walk1_n(__first, __n, [](_ForwardIterator __it)
+                                                                                { ::new (internal::reduce_to_ptr(__it)) _ValueType(); }, __is_vector, __is_parallel); }
         );
 }
 

--- a/include/pstl/internal/glue_memory_impl.h
+++ b/include/pstl/internal/glue_memory_impl.h
@@ -27,11 +27,11 @@
 namespace std {
 
 template<class _ExecutionPolicy, class _InputIterator, class _ForwardIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 uninitialized_copy(_ExecutionPolicy&& __exec, _InputIterator __first, _InputIterator __last, _ForwardIterator __result) {
     typedef typename iterator_traits<_InputIterator>::value_type _ValueType1;
     typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType2;
-    using namespace pstl;
+    using namespace __pstl;;
 
     const auto __is_parallel = internal::is_parallelization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(__exec);
     const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(__exec);
@@ -46,11 +46,11 @@ uninitialized_copy(_ExecutionPolicy&& __exec, _InputIterator __first, _InputIter
 }
 
 template<class _ExecutionPolicy, class _InputIterator, class _Size, class _ForwardIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 uninitialized_copy_n(_ExecutionPolicy&& __exec, _InputIterator __first, _Size __n, _ForwardIterator __result) {
     typedef typename iterator_traits<_InputIterator>::value_type _ValueType1;
     typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType2;
-    using namespace pstl;
+    using namespace __pstl;;
 
     const auto __is_parallel = internal::is_parallelization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(__exec);
     const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(__exec);
@@ -67,11 +67,11 @@ uninitialized_copy_n(_ExecutionPolicy&& __exec, _InputIterator __first, _Size __
 // [uninitialized.move]
 
 template<class _ExecutionPolicy, class _InputIterator, class _ForwardIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 uninitialized_move(_ExecutionPolicy&& __exec, _InputIterator __first, _InputIterator __last, _ForwardIterator __result) {
     typedef typename iterator_traits<_InputIterator>::value_type _ValueType1;
     typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType2;
-    using namespace pstl;
+    using namespace __pstl;;
 
     const auto __is_parallel = internal::is_parallelization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(__exec);
     const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(__exec);
@@ -86,11 +86,11 @@ uninitialized_move(_ExecutionPolicy&& __exec, _InputIterator __first, _InputIter
 }
 
 template<class _ExecutionPolicy, class _InputIterator, class _Size, class _ForwardIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 uninitialized_move_n(_ExecutionPolicy&& __exec, _InputIterator __first, _Size __n, _ForwardIterator __result) {
     typedef typename iterator_traits<_InputIterator>::value_type _ValueType1;
     typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType2;
-    using namespace pstl;
+    using namespace __pstl;;
 
     const auto __is_parallel = internal::is_parallelization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(__exec);
     const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _InputIterator, _ForwardIterator>(__exec);
@@ -107,10 +107,10 @@ uninitialized_move_n(_ExecutionPolicy&& __exec, _InputIterator __first, _Size __
 // [uninitialized.fill]
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _Tp>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
 uninitialized_fill(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, const _Tp& __value) {
     typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
-    using namespace pstl;
+    using namespace __pstl;;
 
     const auto __is_parallel = internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
     const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
@@ -125,10 +125,10 @@ uninitialized_fill(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Forward
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _Size, class _Tp>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 uninitialized_fill_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n, const _Tp& __value) {
     typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
-    using namespace pstl;
+    using namespace __pstl;;
 
     const auto __is_parallel = internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
     const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
@@ -145,10 +145,10 @@ uninitialized_fill_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size 
 // [specialized.destroy]
 
 template <class _ExecutionPolicy, class _ForwardIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
 destroy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last) {
     typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
-    using namespace pstl;
+    using namespace __pstl;;
 
     const auto __is_parallel = internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
     const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
@@ -160,10 +160,10 @@ destroy(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Size>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 destroy_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n) {
     typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
-    using namespace pstl;
+    using namespace __pstl;;
 
     const auto __is_parallel = internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
     const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
@@ -178,10 +178,10 @@ destroy_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n) {
 // [uninitialized.construct.default]
 
 template <class _ExecutionPolicy, class _ForwardIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
 uninitialized_default_construct(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last) {
     typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
-    using namespace pstl;
+    using namespace __pstl;;
 
     const auto __is_parallel = internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
     const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
@@ -192,10 +192,10 @@ uninitialized_default_construct(_ExecutionPolicy&& __exec, _ForwardIterator __fi
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Size>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 uninitialized_default_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n) {
     typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
-    using namespace pstl;
+    using namespace __pstl;;
 
     const auto __is_parallel = internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
     const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
@@ -210,10 +210,10 @@ uninitialized_default_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __
 // [uninitialized.construct.value]
 
 template <class _ExecutionPolicy, class _ForwardIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, void>
 uninitialized_value_construct(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last) {
     typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
-    using namespace pstl;
+    using namespace __pstl;;
 
     const auto __is_parallel = internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
     const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
@@ -227,10 +227,10 @@ uninitialized_value_construct(_ExecutionPolicy&& __exec, _ForwardIterator __firs
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator, class _Size>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator>
 uninitialized_value_construct_n(_ExecutionPolicy&& __exec, _ForwardIterator __first, _Size __n) {
     typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
-    using namespace pstl;
+    using namespace __pstl;;
 
     const auto __is_parallel = internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);
     const auto __is_vector = internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator>(__exec);

--- a/include/pstl/internal/glue_numeric_defs.h
+++ b/include/pstl/internal/glue_numeric_defs.h
@@ -25,83 +25,83 @@
 namespace std {
 // [reduce]
 
-template<class ExecutionPolicy, class ForwardIterator, class T, class BinaryOperation>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,T>
-reduce(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, T init, BinaryOperation binary_op);
+template<class _ExecutionPolicy, class _ForwardIterator, class _Tp, class _BinaryOperation>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
+reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Tp __init, _BinaryOperation __binary_op);
 
-template<class ExecutionPolicy, class ForwardIterator, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,T>
-reduce(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, T init);
+template<class _ExecutionPolicy, class _ForwardIterator, class _Tp>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
+reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Tp __init);
 
-template<class ExecutionPolicy, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,typename iterator_traits<ForwardIterator>::value_type>
-reduce(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last);
+template<class _ExecutionPolicy, class _ForwardIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, typename iterator_traits<_ForwardIterator>::value_type>
+reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last);
 
-template <class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, T>
-transform_reduce(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, T init);
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
+transform_reduce(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _Tp __init);
 
-template <class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class T, class BinaryOperation1, class BinaryOperation2>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, T>
-transform_reduce(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, T init, BinaryOperation1 binary_op1,
-                 BinaryOperation2 binary_op2);
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp, class _BinaryOperation1, class _BinaryOperation2>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
+transform_reduce(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _Tp __init,
+                 _BinaryOperation1 __binary_op1, _BinaryOperation2 __binary_op2);
 
-template<class ExecutionPolicy, class ForwardIterator, class T, class BinaryOperation, class UnaryOperation>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,T>
-transform_reduce(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, T init, BinaryOperation binary_op, UnaryOperation unary_op);
+template<class _ExecutionPolicy, class _ForwardIterator, class _Tp, class _BinaryOperation, class _UnaryOperation>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
+transform_reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Tp __init, _BinaryOperation __binary_op, _UnaryOperation __unary_op);
 
 // [exclusive.scan]
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
-exclusive_scan(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, T init);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+exclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, _Tp __init);
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class T, class BinaryOperation>
-ForwardIterator2 exclusive_scan(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, T init,
-                                BinaryOperation binary_op);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp, class _BinaryOperation>
+_ForwardIterator2 exclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, _Tp __init,
+                                _BinaryOperation __binary_op);
 
 // [inclusive.scan]
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
-inclusive_scan(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+inclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result);
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class BinaryOperation>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
-inclusive_scan(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, BinaryOperation binary_op);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryOperation>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+inclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, _BinaryOperation __binary_op);
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class T, class BinaryOperation>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
-inclusive_scan(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, BinaryOperation binary_op, T init);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp, class _BinaryOperation>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+inclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, _BinaryOperation __binary_op, _Tp __init);
 
 // [transform.exclusive.scan]
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class T, class BinaryOperation, class UnaryOperation>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
-transform_exclusive_scan(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, T init,
-                         BinaryOperation binary_op, UnaryOperation unary_op);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp, class _BinaryOperation, class _UnaryOperation>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+transform_exclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, _Tp __init,
+                         _BinaryOperation __binary_op, _UnaryOperation __unary_op);
 
 // [transform.inclusive.scan]
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class BinaryOperation, class UnaryOperation, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
-transform_inclusive_scan(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, BinaryOperation binary_op,
-                         UnaryOperation unary_op, T init);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryOperation, class _UnaryOperation, class _Tp>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+transform_inclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, _BinaryOperation __binary_op,
+                         _UnaryOperation __unary_op, _Tp __init);
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class UnaryOperation, class BinaryOperation>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
-transform_inclusive_scan(ExecutionPolicy&& exec,  ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, BinaryOperation binary_op,
-                         UnaryOperation unary_op);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _UnaryOperation, class _BinaryOperation>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+transform_inclusive_scan(_ExecutionPolicy&& __exec,  _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, _BinaryOperation __binary_op,
+                         _UnaryOperation __unary_op);
 
 // [adjacent.difference]
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class BinaryOperation>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator2>
-adjacent_difference(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 d_first, BinaryOperation op);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryOperation>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+adjacent_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 d_first, _BinaryOperation op);
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator2>
-adjacent_difference(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 d_first);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+adjacent_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 d_first);
 
 } // namespace std
 #endif /* __PSTL_glue_numeric_defs_H_ */

--- a/include/pstl/internal/glue_numeric_defs.h
+++ b/include/pstl/internal/glue_numeric_defs.h
@@ -26,34 +26,34 @@ namespace std {
 // [reduce]
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _Tp, class _BinaryOperation>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
 reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Tp __init, _BinaryOperation __binary_op);
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _Tp>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
 reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Tp __init);
 
 template<class _ExecutionPolicy, class _ForwardIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, typename iterator_traits<_ForwardIterator>::value_type>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, typename iterator_traits<_ForwardIterator>::value_type>
 reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last);
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
 transform_reduce(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _Tp __init);
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp, class _BinaryOperation1, class _BinaryOperation2>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
 transform_reduce(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _Tp __init,
                  _BinaryOperation1 __binary_op1, _BinaryOperation2 __binary_op2);
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _Tp, class _BinaryOperation, class _UnaryOperation>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
 transform_reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Tp __init, _BinaryOperation __binary_op, _UnaryOperation __unary_op);
 
 // [exclusive.scan]
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
 exclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, _Tp __init);
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp, class _BinaryOperation>
@@ -63,45 +63,45 @@ _ForwardIterator2 exclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __
 // [inclusive.scan]
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
 inclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result);
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryOperation>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
 inclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, _BinaryOperation __binary_op);
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp, class _BinaryOperation>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
 inclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, _BinaryOperation __binary_op, _Tp __init);
 
 // [transform.exclusive.scan]
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp, class _BinaryOperation, class _UnaryOperation>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
 transform_exclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, _Tp __init,
                          _BinaryOperation __binary_op, _UnaryOperation __unary_op);
 
 // [transform.inclusive.scan]
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryOperation, class _UnaryOperation, class _Tp>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
 transform_inclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, _BinaryOperation __binary_op,
                          _UnaryOperation __unary_op, _Tp __init);
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _UnaryOperation, class _BinaryOperation>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
 transform_inclusive_scan(_ExecutionPolicy&& __exec,  _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, _BinaryOperation __binary_op,
                          _UnaryOperation __unary_op);
 
 // [adjacent.difference]
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryOperation>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
-adjacent_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 d_first, _BinaryOperation op);
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+adjacent_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __d_first, _BinaryOperation op);
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
-adjacent_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 d_first);
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+adjacent_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __d_first);
 
 } // namespace std
 #endif /* __PSTL_glue_numeric_defs_H_ */

--- a/include/pstl/internal/glue_numeric_impl.h
+++ b/include/pstl/internal/glue_numeric_impl.h
@@ -30,29 +30,29 @@ namespace std {
 // [transform.reduce]
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
 transform_reduce(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _Tp __init) {
     typedef typename iterator_traits<_ForwardIterator1>::value_type _InputType;
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_transform_reduce(__first1, __last1, __first2, __init, std::plus<_InputType>(), std::multiplies<_InputType>(),
                                               internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
                                               internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
 }
 
 template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp, class _BinaryOperation1, class _BinaryOperation2>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
 transform_reduce(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _Tp __init,
                  _BinaryOperation1 __binary_op1, _BinaryOperation2 __binary_op2) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_transform_reduce(__first1, __last1, __first2, __init, __binary_op1, __binary_op2,
                                               internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
                                               internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _Tp, class _BinaryOperation, class _UnaryOperation>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
 transform_reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Tp __init, _BinaryOperation __binary_op, _UnaryOperation __unary_op) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_transform_reduce(__first, __last, __init, __binary_op, __unary_op,
                                               internal::is_vectorization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec),
                                               internal::is_parallelization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec));
@@ -61,31 +61,31 @@ transform_reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIt
 // [reduce]
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _Tp, class _BinaryOperation>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
 reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Tp __init, _BinaryOperation __binary_op) {
-    return std::transform_reduce(__exec, __first, __last, __init, __binary_op, pstl::internal::no_op());
+    return std::transform_reduce(__exec, __first, __last, __init, __binary_op, __pstl::internal::no_op());
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator, class _Tp>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
 reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Tp __init) {
-  return std::transform_reduce(__exec, __first, __last, __init, std::plus<_Tp>(), pstl::internal::no_op());
+  return std::transform_reduce(__exec, __first, __last, __init, std::plus<_Tp>(), __pstl::internal::no_op());
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy,typename iterator_traits<_ForwardIterator>::value_type>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,typename iterator_traits<_ForwardIterator>::value_type>
 reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last) {
-    typedef typename iterator_traits<_ForwardIterator>::value_type _Tp;
-    return std::transform_reduce(__exec, __first, __last, _Tp{}, std::plus<_Tp>(), pstl::internal::no_op());
+    typedef typename iterator_traits<_ForwardIterator>::value_type _value_type;
+    return std::transform_reduce(__exec, __first, __last, _value_type{}, std::plus<_value_type>(), __pstl::internal::no_op());
 }
 
 // [transform.exclusive.scan]
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp, class _BinaryOperation, class _UnaryOperation>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
 transform_exclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, _Tp __init,
                          _BinaryOperation __binary_op, _UnaryOperation __unary_op) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_transform_scan(
         __first, __last, __result, __unary_op, __init, __binary_op,
         /*inclusive=*/std::false_type(),
@@ -96,10 +96,10 @@ transform_exclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _
 // [transform.inclusive.scan]
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryOperation, class _UnaryOperation, class _Tp>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
 transform_inclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result,
                          _BinaryOperation __binary_op, _UnaryOperation __unary_op, _Tp __init) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_transform_scan(__first, __last, __result, __unary_op, __init, __binary_op,
                                             /*inclusive=*/std::true_type(),
                                             internal::is_vectorization_preferred<_ExecutionPolicy,_ForwardIterator1,_ForwardIterator2>(__exec),
@@ -107,7 +107,7 @@ transform_inclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _UnaryOperation, class _BinaryOperation>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
 transform_inclusive_scan(_ExecutionPolicy&& __exec,  _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result,
                          _BinaryOperation __binary_op, _UnaryOperation __unary_op) {
     if( __first != __last ) {
@@ -121,52 +121,52 @@ transform_inclusive_scan(_ExecutionPolicy&& __exec,  _ForwardIterator1 __first, 
 // [exclusive.scan]
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
 exclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, _Tp __init) {
-    return std::transform_exclusive_scan(__exec, __first, __last, __result, __init, std::plus<_Tp>(), pstl::internal::no_op());
+    return std::transform_exclusive_scan(__exec, __first, __last, __result, __init, std::plus<_Tp>(), __pstl::internal::no_op());
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp, class _BinaryOperation>
 _ForwardIterator2 exclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, _Tp __init,
                                  _BinaryOperation __binary_op) {
-  return std::transform_exclusive_scan(__exec, __first, __last, __result, __init, __binary_op, pstl::internal::no_op());
+  return std::transform_exclusive_scan(__exec, __first, __last, __result, __init, __binary_op, __pstl::internal::no_op());
 }
 
 // [inclusive.scan]
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
 inclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result) {
     typedef typename iterator_traits<_ForwardIterator1>::value_type _InputType;
-    return std::transform_inclusive_scan(__exec, __first, __last, __result, std::plus<_InputType>(), pstl::internal::no_op());
+    return std::transform_inclusive_scan(__exec, __first, __last, __result, std::plus<_InputType>(), __pstl::internal::no_op());
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryOperation>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
 inclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, _BinaryOperation __binary_op) {
-    return std::transform_inclusive_scan(__exec, __first, __last, __result, __binary_op, pstl::internal::no_op());
+    return std::transform_inclusive_scan(__exec, __first, __last, __result, __binary_op, __pstl::internal::no_op());
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp, class _BinaryOperation>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
 inclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result,
                _BinaryOperation __binary_op, _Tp __init) {
-    return std::transform_inclusive_scan(__exec, __first, __last, __result, __binary_op, pstl::internal::no_op(), __init);
+    return std::transform_inclusive_scan(__exec, __first, __last, __result, __binary_op, __pstl::internal::no_op(), __init);
 }
 
 // [adjacent.difference]
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryOperation>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
 adjacent_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __d_first, _BinaryOperation __op) {
-    using namespace pstl;
+    using namespace __pstl;
     return internal::pattern_adjacent_difference(__first, __last, __d_first, __op,
                                                  internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
                                                  internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
 }
 
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
-pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+__pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
 adjacent_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __d_first) {
     typedef typename iterator_traits<_ForwardIterator1>::value_type value_type;
     return std::adjacent_difference(__exec, __first, __last, __d_first, std::minus<value_type>());

--- a/include/pstl/internal/glue_numeric_impl.h
+++ b/include/pstl/internal/glue_numeric_impl.h
@@ -27,145 +27,149 @@
 
 namespace std {
 
-// [reduce]
-
-template<class ExecutionPolicy, class ForwardIterator, class T, class BinaryOperation>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,T>
-reduce(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, T init, BinaryOperation binary_op) {
-    return transform_reduce(exec, first, last, init, binary_op, pstl::internal::no_op());
-}
-
-template<class ExecutionPolicy, class ForwardIterator, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,T>
-reduce(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, T init) {
-    return transform_reduce(exec, first, last, init, std::plus<T>(), pstl::internal::no_op());
-}
-
-template<class ExecutionPolicy, class ForwardIterator>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,typename iterator_traits<ForwardIterator>::value_type>
-reduce(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last) {
-    typedef typename iterator_traits<ForwardIterator>::value_type T;
-    return transform_reduce(exec, first, last, T{}, std::plus<T>(), pstl::internal::no_op());
-}
-
 // [transform.reduce]
 
-template <class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, T>
-transform_reduce(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, T init) {
-    typedef typename iterator_traits<ForwardIterator1>::value_type input_type;
-    using namespace pstl::internal;
-    return pattern_transform_reduce(first1, last1, first2, init, std::plus<input_type>(), std::multiplies<input_type>(),
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec),
-        is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec));
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
+transform_reduce(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _Tp __init) {
+    typedef typename iterator_traits<_ForwardIterator1>::value_type _InputType;
+    using namespace pstl;
+    return internal::pattern_transform_reduce(__first1, __last1, __first2, __init, std::plus<_InputType>(), std::multiplies<_InputType>(),
+                                              internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
+                                              internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
 }
 
-template <class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class T, class BinaryOperation1, class BinaryOperation2>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, T>
-transform_reduce(ExecutionPolicy&& exec, ForwardIterator1 first1, ForwardIterator1 last1, ForwardIterator2 first2, T init, BinaryOperation1 binary_op1, BinaryOperation2 binary_op2) {
-    using namespace pstl::internal;
-    return pattern_transform_reduce(first1, last1, first2, init, binary_op1, binary_op2,
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec),
-        is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec));
+template <class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp, class _BinaryOperation1, class _BinaryOperation2>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
+transform_reduce(_ExecutionPolicy&& __exec, _ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _Tp __init,
+                 _BinaryOperation1 __binary_op1, _BinaryOperation2 __binary_op2) {
+    using namespace pstl;
+    return internal::pattern_transform_reduce(__first1, __last1, __first2, __init, __binary_op1, __binary_op2,
+                                              internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
+                                              internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
 }
 
-template<class ExecutionPolicy, class ForwardIterator, class T, class BinaryOperation, class UnaryOperation>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,T>
-transform_reduce(ExecutionPolicy&& exec, ForwardIterator first, ForwardIterator last, T init, BinaryOperation binary_op, UnaryOperation unary_op) {
-    using namespace pstl::internal;
-    return pattern_transform_reduce(first, last, init, binary_op, unary_op,
-        is_vectorization_preferred<ExecutionPolicy,ForwardIterator>(exec),
-        is_parallelization_preferred<ExecutionPolicy,ForwardIterator>(exec));
+template<class _ExecutionPolicy, class _ForwardIterator, class _Tp, class _BinaryOperation, class _UnaryOperation>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
+transform_reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Tp __init, _BinaryOperation __binary_op, _UnaryOperation __unary_op) {
+    using namespace pstl;
+    return internal::pattern_transform_reduce(__first, __last, __init, __binary_op, __unary_op,
+                                              internal::is_vectorization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec),
+                                              internal::is_parallelization_preferred<_ExecutionPolicy,_ForwardIterator>(__exec));
 }
 
-// [exclusive.scan]
+// [reduce]
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
-exclusive_scan(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, T init) {
-    return transform_exclusive_scan(exec, first, last, result, init, std::plus<T>(), pstl::internal::no_op());
+template<class _ExecutionPolicy, class _ForwardIterator, class _Tp, class _BinaryOperation>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
+reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Tp __init, _BinaryOperation __binary_op) {
+    return std::transform_reduce(__exec, __first, __last, __init, __binary_op, pstl::internal::no_op());
 }
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class T, class BinaryOperation>
-ForwardIterator2 exclusive_scan(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, T init, BinaryOperation binary_op) {
-    return transform_exclusive_scan(exec, first, last, result, init, binary_op, pstl::internal::no_op());
+template<class _ExecutionPolicy, class _ForwardIterator, class _Tp>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _Tp>
+reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last, _Tp __init) {
+  return std::transform_reduce(__exec, __first, __last, __init, std::plus<_Tp>(), pstl::internal::no_op());
 }
 
-// [inclusive.scan]
-
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
-inclusive_scan(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result) {
-    typedef typename iterator_traits<ForwardIterator1>::value_type input_type;
-    return transform_inclusive_scan(exec, first, last, result, std::plus<input_type>(), pstl::internal::no_op());
-}
-
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class BinaryOperation>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
-inclusive_scan(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, BinaryOperation binary_op) {
-    return transform_inclusive_scan(exec, first, last, result, binary_op, pstl::internal::no_op());
-}
-
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class T, class BinaryOperation>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
-inclusive_scan(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, BinaryOperation binary_op, T init) {
-    return transform_inclusive_scan(exec, first, last, result, binary_op, pstl::internal::no_op(), init);
+template<class _ExecutionPolicy, class _ForwardIterator>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy,typename iterator_traits<_ForwardIterator>::value_type>
+reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last) {
+    typedef typename iterator_traits<_ForwardIterator>::value_type _Tp;
+    return std::transform_reduce(__exec, __first, __last, _Tp{}, std::plus<_Tp>(), pstl::internal::no_op());
 }
 
 // [transform.exclusive.scan]
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class T, class BinaryOperation, class UnaryOperation>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
-transform_exclusive_scan(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, T init, BinaryOperation binary_op, UnaryOperation unary_op) {
-    using namespace pstl::internal;
-    return pattern_transform_scan(
-        first, last, result, unary_op, init, binary_op,
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp, class _BinaryOperation, class _UnaryOperation>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+transform_exclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, _Tp __init,
+                         _BinaryOperation __binary_op, _UnaryOperation __unary_op) {
+    using namespace pstl;
+    return internal::pattern_transform_scan(
+        __first, __last, __result, __unary_op, __init, __binary_op,
         /*inclusive=*/std::false_type(),
-        is_vectorization_preferred<ExecutionPolicy,ForwardIterator1,ForwardIterator2>(exec),
-        is_parallelization_preferred<ExecutionPolicy,ForwardIterator1,ForwardIterator2>(exec));
+        internal::is_vectorization_preferred<_ExecutionPolicy,_ForwardIterator1,_ForwardIterator2>(__exec),
+        internal::is_parallelization_preferred<_ExecutionPolicy,_ForwardIterator1,_ForwardIterator2>(__exec));
 }
 
 // [transform.inclusive.scan]
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class BinaryOperation, class UnaryOperation, class T>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
-transform_inclusive_scan(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, BinaryOperation binary_op, UnaryOperation unary_op, T init) {
-    using namespace pstl::internal;
-    return pattern_transform_scan(
-        first, last, result, unary_op, init, binary_op,
-        /*inclusive=*/std::true_type(),
-        is_vectorization_preferred<ExecutionPolicy,ForwardIterator1,ForwardIterator2>(exec),
-        is_parallelization_preferred<ExecutionPolicy,ForwardIterator1,ForwardIterator2>(exec));
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryOperation, class _UnaryOperation, class _Tp>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+transform_inclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result,
+                         _BinaryOperation __binary_op, _UnaryOperation __unary_op, _Tp __init) {
+    using namespace pstl;
+    return internal::pattern_transform_scan(__first, __last, __result, __unary_op, __init, __binary_op,
+                                            /*inclusive=*/std::true_type(),
+                                            internal::is_vectorization_preferred<_ExecutionPolicy,_ForwardIterator1,_ForwardIterator2>(__exec),
+                                            internal::is_parallelization_preferred<_ExecutionPolicy,_ForwardIterator1,_ForwardIterator2>(__exec));
 }
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class UnaryOperation, class BinaryOperation>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy,ForwardIterator2>
-transform_inclusive_scan(ExecutionPolicy&& exec,  ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 result, BinaryOperation binary_op, UnaryOperation unary_op) {
-    if( first!=last ) {
-        auto tmp = unary_op(*first);
-        *result = tmp;
-        return transform_inclusive_scan(exec, ++first, last, ++result, binary_op, unary_op, tmp);
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _UnaryOperation, class _BinaryOperation>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+transform_inclusive_scan(_ExecutionPolicy&& __exec,  _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result,
+                         _BinaryOperation __binary_op, _UnaryOperation __unary_op) {
+    if( __first != __last ) {
+        auto __tmp = __unary_op(*__first);
+        *__result = __tmp;
+        return std::transform_inclusive_scan(__exec, ++__first, __last, ++__result, __binary_op, __unary_op, __tmp);
     } else {
-        return result;
+        return __result;
     }
+}
+// [exclusive.scan]
+
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+exclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, _Tp __init) {
+    return std::transform_exclusive_scan(__exec, __first, __last, __result, __init, std::plus<_Tp>(), pstl::internal::no_op());
+}
+
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp, class _BinaryOperation>
+_ForwardIterator2 exclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, _Tp __init,
+                                 _BinaryOperation __binary_op) {
+  return std::transform_exclusive_scan(__exec, __first, __last, __result, __init, __binary_op, pstl::internal::no_op());
+}
+
+// [inclusive.scan]
+
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+inclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result) {
+    typedef typename iterator_traits<_ForwardIterator1>::value_type _InputType;
+    return std::transform_inclusive_scan(__exec, __first, __last, __result, std::plus<_InputType>(), pstl::internal::no_op());
+}
+
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryOperation>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+inclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result, _BinaryOperation __binary_op) {
+    return std::transform_inclusive_scan(__exec, __first, __last, __result, __binary_op, pstl::internal::no_op());
+}
+
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _Tp, class _BinaryOperation>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy,_ForwardIterator2>
+inclusive_scan(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __result,
+               _BinaryOperation __binary_op, _Tp __init) {
+    return std::transform_inclusive_scan(__exec, __first, __last, __result, __binary_op, pstl::internal::no_op(), __init);
 }
 
 // [adjacent.difference]
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2, class BinaryOperation>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator2>
-adjacent_difference(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 d_first, BinaryOperation op) {
-    using namespace pstl::internal;
-    return pattern_adjacent_difference(first, last, d_first, op,
-        is_vectorization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec),
-        is_parallelization_preferred<ExecutionPolicy, ForwardIterator1, ForwardIterator2>(exec));
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2, class _BinaryOperation>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+adjacent_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __d_first, _BinaryOperation __op) {
+    using namespace pstl;
+    return internal::pattern_adjacent_difference(__first, __last, __d_first, __op,
+                                                 internal::is_vectorization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec),
+                                                 internal::is_parallelization_preferred<_ExecutionPolicy, _ForwardIterator1, _ForwardIterator2>(__exec));
 }
 
-template<class ExecutionPolicy, class ForwardIterator1, class ForwardIterator2>
-pstl::internal::enable_if_execution_policy<ExecutionPolicy, ForwardIterator2>
-adjacent_difference(ExecutionPolicy&& exec, ForwardIterator1 first, ForwardIterator1 last, ForwardIterator2 d_first) {
-    typedef typename iterator_traits<ForwardIterator1>::value_type value_type;
-    return adjacent_difference(exec, first, last, d_first, std::minus<value_type>());
+template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
+pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
+adjacent_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __d_first) {
+    typedef typename iterator_traits<_ForwardIterator1>::value_type value_type;
+    return std::adjacent_difference(__exec, __first, __last, __d_first, std::minus<value_type>());
 }
 } // namespace std
 #endif /* __PSTL_glue_numeric_impl_H_ */

--- a/include/pstl/internal/glue_numeric_impl.h
+++ b/include/pstl/internal/glue_numeric_impl.h
@@ -75,8 +75,8 @@ reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __l
 template<class _ExecutionPolicy, class _ForwardIterator>
 __pstl::internal::enable_if_execution_policy<_ExecutionPolicy,typename iterator_traits<_ForwardIterator>::value_type>
 reduce(_ExecutionPolicy&& __exec, _ForwardIterator __first, _ForwardIterator __last) {
-    typedef typename iterator_traits<_ForwardIterator>::value_type _value_type;
-    return std::transform_reduce(__exec, __first, __last, _value_type{}, std::plus<_value_type>(), __pstl::internal::no_op());
+    typedef typename iterator_traits<_ForwardIterator>::value_type _ValueType;
+    return std::transform_reduce(__exec, __first, __last, _ValueType{}, std::plus<_ValueType>(), __pstl::internal::no_op());
 }
 
 // [transform.exclusive.scan]
@@ -168,8 +168,8 @@ adjacent_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _Forwa
 template<class _ExecutionPolicy, class _ForwardIterator1, class _ForwardIterator2>
 __pstl::internal::enable_if_execution_policy<_ExecutionPolicy, _ForwardIterator2>
 adjacent_difference(_ExecutionPolicy&& __exec, _ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __d_first) {
-    typedef typename iterator_traits<_ForwardIterator1>::value_type value_type;
-    return std::adjacent_difference(__exec, __first, __last, __d_first, std::minus<value_type>());
+    typedef typename iterator_traits<_ForwardIterator1>::value_type _ValueType;
+    return std::adjacent_difference(__exec, __first, __last, __d_first, std::minus<_ValueType>());
 }
 } // namespace std
 #endif /* __PSTL_glue_numeric_impl_H_ */

--- a/include/pstl/internal/numeric_impl.h
+++ b/include/pstl/internal/numeric_impl.h
@@ -191,7 +191,7 @@ template<class _RandomAccessIterator, class _OutputIterator, class _UnaryOperati
 _OutputIterator pattern_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __last, _OutputIterator __result,
                                        _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op, _Inclusive,
                                        _IsVector __is_vector, /*is_parallel=*/std::true_type ) {
-    typedef typename std::iterator_traits<_RandomAccessIterator>::difference_type _difference_type;
+    typedef typename std::iterator_traits<_RandomAccessIterator>::difference_type _DifferenceType;
 
     return internal::except_handler([=]() {
         par_backend::parallel_transform_scan(
@@ -199,10 +199,10 @@ _OutputIterator pattern_transform_scan(_RandomAccessIterator __first, _RandomAcc
             [__first, __unary_op](size_t __i) mutable {return __unary_op(__first[__i]); },
             __init,
             __binary_op,
-            [__first, __unary_op, __binary_op, __is_vector](_difference_type __i, _difference_type __j, _Tp __init) {
+            [__first, __unary_op, __binary_op, __is_vector](_DifferenceType __i, _DifferenceType __j, _Tp __init) {
               return internal::brick_transform_reduce(__first + __i, __first + __j, __init, __binary_op, __unary_op, __is_vector);
         },
-        [__first, __unary_op, __binary_op, __result](_difference_type __i, _difference_type __j, _Tp __init) {
+        [__first, __unary_op, __binary_op, __result](_DifferenceType __i, _DifferenceType __j, _Tp __init) {
           return internal::brick_transform_scan(__first + __i, __first + __j, __result + __i, __unary_op, __init, __binary_op, _Inclusive()).second;
         });
         return __result + (__last - __first);

--- a/include/pstl/internal/numeric_impl.h
+++ b/include/pstl/internal/numeric_impl.h
@@ -32,70 +32,79 @@
     #include "parallel_backend.h"
 #endif
 
-namespace pstl {
+namespace __pstl {
 namespace internal {
 //------------------------------------------------------------------------
 // transform_reduce (version with two binary functions, according to draft N4659)
 //------------------------------------------------------------------------
 
-template< class T, class BinaryOperation1, class IsArithmeticIsVector>
+template< class _Tp, class _BinaryOperation1, class _IsArithmeticIsVector>
 struct brick_transform_reduce_imp {
 
-    template<class InputIterator1, class InputIterator2, class BinaryOperation2>
-    T operator()(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, T init, BinaryOperation1 binary_op1, BinaryOperation2 binary_op2) noexcept {
-        return std::inner_product(first1, last1, first2, init, binary_op1, binary_op2);
+    template<class _ForwardIterator1, class _ForwardIterator2, class _BinaryOperation2>
+    _Tp operator()(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2,
+                 _Tp __init, _BinaryOperation1 __binary_op1, _BinaryOperation2 __binary_op2) noexcept {
+        return std::inner_product(__first1, __last1, __first2, __init, __binary_op1, __binary_op2);
     }
 
-    template< class InputIterator, class UnaryOperation>
-    T operator()(InputIterator first, InputIterator last, T init, BinaryOperation1 binary_op, UnaryOperation unary_op) noexcept {
-        for (; first != last; ++first) {
-            init = binary_op(init, unary_op(*first));
+    template< class _ForwardIterator, class _UnaryOperation>
+    _Tp operator()(_ForwardIterator __first, _ForwardIterator __last, _Tp __init,
+                 _BinaryOperation1 __binary_op, _UnaryOperation __unary_op) noexcept {
+        for (; __first != __last; ++__first) {
+            __init = __binary_op(__init, __unary_op(*__first));
         }
-        return init;
+        return __init;
     }
 };
 
-template< class T>
-struct brick_transform_reduce_imp<T, std::plus<T>, /*IsArithmeticIsVector*/ std::true_type> {
+template< class _Tp>
+struct brick_transform_reduce_imp<_Tp, std::plus<_Tp>, /*_IsArithmeticIsVector*/ std::true_type> {
 
-    template<class InputIterator1, class InputIterator2, class BinaryOperation2>
-    T operator()(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, T init, std::plus<T>, BinaryOperation2 binary_op2) noexcept {
-        return unseq_backend::simd_transform_reduce(first1, last1-first1, first2, init, binary_op2);
+    template<class _RandomAccessIterator1, class _RandomAccessIterator2, class _BinaryOperation2>
+    _Tp operator()(_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2, _Tp __init,
+                   std::plus<_Tp>, _BinaryOperation2 __binary_op2) noexcept {
+        return unseq_backend::simd_transform_reduce(__first1, __last1 - __first1, __first2, __init, __binary_op2);
     }
 
-    template< class InputIterator, class UnaryOperation>
-    T operator()(InputIterator first, InputIterator last, T init, std::plus<T>, UnaryOperation unary_op) noexcept {
-        return unseq_backend::simd_transform_reduce(first, last-first, init, unary_op);
+    template< class _RandomAccessIterator, class _UnaryOperation>
+    _Tp operator()(_RandomAccessIterator __first, _RandomAccessIterator __last, _Tp __init,
+                   std::plus<_Tp>, _UnaryOperation __unary_op) noexcept {
+        return unseq_backend::simd_transform_reduce(__first, __last - __first, __init, __unary_op);
     }
 };
 
-template<class InputIterator1, class InputIterator2, class T, class BinaryOperation1, class BinaryOperation2>
-T brick_transform_reduce(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, T init, BinaryOperation1 binary_op1, BinaryOperation2 binary_op2, /*is_vector=*/std::true_type) noexcept {
-
-    return brick_transform_reduce_imp< T, BinaryOperation1, std::integral_constant<bool, std::is_arithmetic<T>::value> >()(first1, last1, first2, init, binary_op1, binary_op2);
+template<class _ForwardIterator1, class _ForwardIterator2, class _Tp, class _BinaryOperation1, class _BinaryOperation2>
+_Tp brick_transform_reduce(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _Tp __init,
+                           _BinaryOperation1 __binary_op1, _BinaryOperation2 __binary_op2, /*__is_vector=*/std::true_type) noexcept {
+    return internal::brick_transform_reduce_imp< _Tp, _BinaryOperation1, std::integral_constant<bool, std::is_arithmetic<_Tp>::value>>()(__first1, __last1, __first2, __init, __binary_op1, __binary_op2);
 }
 
-template<class InputIterator1, class InputIterator2, class T, class BinaryOperation1, class BinaryOperation2>
-T brick_transform_reduce(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, T init, BinaryOperation1 binary_op1, BinaryOperation2 binary_op2, /*is_vector=*/std::false_type) noexcept {
-
-    return brick_transform_reduce_imp< T, BinaryOperation1, std::false_type >()(first1, last1, first2, init, binary_op1, binary_op2);
+template<class _ForwardIterator1, class _ForwardIterator2, class _Tp, class _BinaryOperation1, class _BinaryOperation2>
+_Tp brick_transform_reduce(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _Tp __init,
+                           _BinaryOperation1 __binary_op1, _BinaryOperation2 __binary_op2, /*__is_vector=*/std::false_type) noexcept {
+  return internal::brick_transform_reduce_imp< _Tp, _BinaryOperation1, std::false_type>()(__first1, __last1, __first2, __init, __binary_op1, __binary_op2);
 }
 
-template<class InputIterator1, class InputIterator2, class T, class BinaryOperation1, class BinaryOperation2, class IsVector>
-T pattern_transform_reduce(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, T init, BinaryOperation1 binary_op1, BinaryOperation2 binary_op2, IsVector is_vector, /*is_parallel=*/std::false_type) noexcept {
-    return brick_transform_reduce(first1, last1, first2, init, binary_op1, binary_op2, is_vector);
+template<class _ForwardIterator1, class _ForwardIterator2, class _Tp, class _BinaryOperation1, class _BinaryOperation2, class _IsVector>
+_Tp pattern_transform_reduce(_ForwardIterator1 __first1, _ForwardIterator1 __last1, _ForwardIterator2 __first2, _Tp __init,
+                             _BinaryOperation1 __binary_op1, _BinaryOperation2 __binary_op2, _IsVector __is_vector,
+                             /*is_parallel=*/std::false_type) noexcept {
+    return internal::brick_transform_reduce(__first1, __last1, __first2, __init, __binary_op1, __binary_op2, __is_vector);
 }
 
-template<class InputIterator1, class InputIterator2, class T, class BinaryOperation1, class BinaryOperation2, class IsVector>
-T pattern_transform_reduce(InputIterator1 first1, InputIterator1 last1, InputIterator2 first2, T init, BinaryOperation1 binary_op1, BinaryOperation2 binary_op2, IsVector is_vector,  /*is_parallel=*/std::true_type) noexcept {
-    return except_handler([&]() {
-        return par_backend::parallel_transform_reduce(first1, last1,
-            [first1, first2, binary_op2](InputIterator1 i) mutable { return binary_op2(*i, *(first2 + (i - first1))); },
-            init,
-            binary_op1, // Combine
-            [first1, first2, binary_op1, binary_op2, is_vector](InputIterator1 i, InputIterator1 j, T init) -> T {
-            return brick_transform_reduce(i, j, first2 + (i - first1),
-                init, binary_op1, binary_op2, is_vector);
+template<class _RandomAccessIterator1, class _RandomAccessIterator2, class _Tp, class _BinaryOperation1, class _BinaryOperation2,
+         class _IsVector>
+_Tp pattern_transform_reduce(_RandomAccessIterator1 __first1, _RandomAccessIterator1 __last1, _RandomAccessIterator2 __first2, _Tp __init, _BinaryOperation1 __binary_op1, _BinaryOperation2 __binary_op2, _IsVector __is_vector,  /*is_parallel=*/std::true_type) noexcept {
+    return internal::except_handler([&]() {
+        return par_backend::parallel_transform_reduce(__first1, __last1,
+            [__first1, __first2, __binary_op2](_RandomAccessIterator1 __i) mutable
+                                                      { return __binary_op2(*__i, *(__first2 + (__i - __first1))); },
+            __init,
+            __binary_op1, // Combine
+            [__first1, __first2, __binary_op1,
+             __binary_op2, __is_vector](_RandomAccessIterator1 __i, _RandomAccessIterator1 __j, _Tp __init) -> _Tp {
+                return internal::brick_transform_reduce(__i, __j, __first2 + (__i - __first1),
+                                                        __init, __binary_op1, __binary_op2, __is_vector);
         });
     });
 }
@@ -104,31 +113,36 @@ T pattern_transform_reduce(InputIterator1 first1, InputIterator1 last1, InputIte
 // transform_reduce (version with unary and binary functions)
 //------------------------------------------------------------------------
 
-template< class InputIterator, class T, class UnaryOperation, class BinaryOperation >
-T brick_transform_reduce(InputIterator first, InputIterator last, T init, BinaryOperation binary_op, UnaryOperation unary_op, /*is_vector=*/std::true_type) noexcept {
-    return brick_transform_reduce_imp< T, BinaryOperation, std::integral_constant<bool, std::is_arithmetic<T>::value> >()(first, last, init, binary_op, unary_op);
+template< class _ForwardIterator, class _Tp, class _UnaryOperation, class _BinaryOperation >
+_Tp brick_transform_reduce(_ForwardIterator __first, _ForwardIterator __last, _Tp __init, _BinaryOperation __binary_op,
+                           _UnaryOperation __unary_op, /*is_vector=*/std::true_type) noexcept {
+    return internal::brick_transform_reduce_imp< _Tp, _BinaryOperation,
+                                       std::integral_constant<bool, std::is_arithmetic<_Tp>::value> >()(__first, __last, __init,
+                                                                                                        __binary_op, __unary_op);
 }
 
-template< class InputIterator, class T, class BinaryOperation, class UnaryOperation >
-T brick_transform_reduce(InputIterator first, InputIterator last, T init, BinaryOperation binary_op, UnaryOperation unary_op, /*is_vector=*/std::false_type) noexcept {
-
-    return brick_transform_reduce_imp< T, BinaryOperation, std::false_type >()(first, last, init, binary_op, unary_op);
+template< class _ForwardIterator, class _Tp, class _BinaryOperation, class _UnaryOperation >
+_Tp brick_transform_reduce(_ForwardIterator __first, _ForwardIterator __last, _Tp __init, _BinaryOperation __binary_op,
+                           _UnaryOperation __unary_op, /*is_vector=*/std::false_type) noexcept {
+    return internal::brick_transform_reduce_imp< _Tp, _BinaryOperation, std::false_type >()(__first, __last, __init, __binary_op, __unary_op);
 }
 
-template<class InputIterator, class T, class BinaryOperation, class UnaryOperation, class IsVector>
-T pattern_transform_reduce(InputIterator first, InputIterator last, T init, BinaryOperation binary_op, UnaryOperation unary_op, IsVector is_vector, /*is_parallel=*/std::false_type ) noexcept {
-    return brick_transform_reduce(first, last, init, binary_op, unary_op, is_vector);
+template<class _ForwardIterator, class _Tp, class _BinaryOperation, class _UnaryOperation, class _IsVector>
+_Tp pattern_transform_reduce(_ForwardIterator __first, _ForwardIterator __last, _Tp __init, _BinaryOperation __binary_op,
+                             _UnaryOperation __unary_op, _IsVector __is_vector, /*is_parallel=*/std::false_type ) noexcept {
+    return internal::brick_transform_reduce(__first, __last, __init, __binary_op, __unary_op, __is_vector);
 }
 
-template<class InputIterator, class T, class BinaryOperation, class UnaryOperation, class IsVector>
-T pattern_transform_reduce(InputIterator first, InputIterator last, T init, BinaryOperation binary_op, UnaryOperation unary_op, IsVector is_vector, /*is_parallel=*/std::true_type) {
-    return except_handler([&]() {
-        return par_backend::parallel_transform_reduce(first, last,
-            [unary_op](InputIterator i) mutable {return unary_op(*i); },
-            init,
-            binary_op,
-            [unary_op, binary_op, is_vector](InputIterator i, InputIterator j, T init) {
-            return brick_transform_reduce(i, j, init, binary_op, unary_op, is_vector);
+template<class _ForwardIterator, class _Tp, class _BinaryOperation, class _UnaryOperation, class _IsVector>
+_Tp pattern_transform_reduce(_ForwardIterator __first, _ForwardIterator __last, _Tp __init, _BinaryOperation __binary_op,
+                             _UnaryOperation __unary_op, _IsVector __is_vector, /*is_parallel=*/std::true_type) {
+    return internal::except_handler([&]() {
+        return par_backend::parallel_transform_reduce(__first, __last,
+            [__unary_op](_ForwardIterator __i) mutable {return __unary_op(*__i); },
+            __init,
+            __binary_op,
+            [__unary_op, __binary_op, __is_vector](_ForwardIterator i, _ForwardIterator j, _Tp __init) {
+              return internal::brick_transform_reduce(i, j, __init, __binary_op, __unary_op, __is_vector);
         });
     });
 }
@@ -141,47 +155,57 @@ T pattern_transform_reduce(InputIterator first, InputIterator last, T init, Bina
 //------------------------------------------------------------------------
 
 // Exclusive form
-template<class InputIterator, class OutputIterator, class UnaryOperation, class T, class BinaryOperation>
-std::pair<OutputIterator,T> brick_transform_scan(InputIterator first, InputIterator last, OutputIterator result, UnaryOperation unary_op, T init, BinaryOperation binary_op, /*Inclusive*/ std::false_type) noexcept {
-    for(; first!=last; ++first, ++result ) {
-        *result = init;
-        init = binary_op(init,unary_op(*first));
+template<class _ForwardIterator, class _OutputIterator, class _UnaryOperation, class _Tp, class _BinaryOperation>
+std::pair<_OutputIterator,_Tp> brick_transform_scan(_ForwardIterator __first, _ForwardIterator __last, _OutputIterator __result,
+                                                    _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op,
+                                                    /*Inclusive*/ std::false_type) noexcept {
+    for(; __first!=__last; ++__first, ++__result ) {
+        *__result = __init;
+        __init = __binary_op(__init,__unary_op(*__first));
     }
-    return std::make_pair(result,init);
+    return std::make_pair(__result,__init);
 }
 
 // Inclusive form
-template<class InputIterator, class OutputIterator, class UnaryOperation, class T, class BinaryOperation>
-std::pair<OutputIterator,T> brick_transform_scan(InputIterator first, InputIterator last, OutputIterator result, UnaryOperation unary_op, T init, BinaryOperation binary_op, /*Inclusive*/std::true_type) noexcept {
-    for(; first!=last; ++first, ++result ) {
-        init = binary_op(init,unary_op(*first));
-        *result = init;
+template<class _ForwardIterator, class _OutputIterator, class _UnaryOperation, class _Tp, class _BinaryOperation>
+std::pair<_OutputIterator,_Tp> brick_transform_scan(_ForwardIterator __first, _ForwardIterator __last, _OutputIterator __result,
+                                                    _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op,
+                                                    /*Inclusive*/std::true_type) noexcept {
+    for(; __first!=__last; ++__first, ++__result ) {
+        __init = __binary_op(__init,__unary_op(*__first));
+        *__result = __init;
     }
-    return std::make_pair(result,init);
+    return std::make_pair(__result,__init);
 }
 
-template<class InputIterator, class OutputIterator, class UnaryOperation, class T, class BinaryOperation, class Inclusive, class IsVector>
-OutputIterator pattern_transform_scan(InputIterator first, InputIterator last, OutputIterator result, UnaryOperation unary_op, T init, BinaryOperation binary_op, Inclusive, IsVector is_vector, /*is_parallel=*/std::false_type ) noexcept {
-    return brick_transform_scan(first, last, result, unary_op, init, binary_op, Inclusive()).first;
+template<class _ForwardIterator, class _OutputIterator, class _UnaryOperation, class _Tp, class _BinaryOperation,
+         class _Inclusive, class _IsVector>
+_OutputIterator pattern_transform_scan(_ForwardIterator __first, _ForwardIterator __last, _OutputIterator __result,
+                                       _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op, _Inclusive,
+                                       _IsVector, /*is_parallel=*/std::false_type ) noexcept {
+    return internal::brick_transform_scan(__first, __last, __result, __unary_op, __init, __binary_op, _Inclusive()).first;
 }
 
-template<class InputIterator, class OutputIterator, class UnaryOperation, class T, class BinaryOperation, class Inclusive, class IsVector>
-OutputIterator pattern_transform_scan(InputIterator first, InputIterator last, OutputIterator result, UnaryOperation unary_op, T init, BinaryOperation binary_op, Inclusive, IsVector is_vector, /*is_parallel=*/std::true_type ) {
-    typedef typename std::iterator_traits<InputIterator>::difference_type difference_type;
+template<class _RandomAccessIterator, class _OutputIterator, class _UnaryOperation, class _Tp, class _BinaryOperation,
+         class _Inclusive, class _IsVector>
+_OutputIterator pattern_transform_scan(_RandomAccessIterator __first, _RandomAccessIterator __last, _OutputIterator __result,
+                                       _UnaryOperation __unary_op, _Tp __init, _BinaryOperation __binary_op, _Inclusive,
+                                       _IsVector __is_vector, /*is_parallel=*/std::true_type ) {
+    typedef typename std::iterator_traits<_RandomAccessIterator>::difference_type _difference_type;
 
-    return except_handler([=]() {
+    return internal::except_handler([=]() {
         par_backend::parallel_transform_scan(
-            last-first,
-            [first, unary_op](size_t i) mutable {return unary_op(first[i]); },
-            init,
-            binary_op,
-            [first, unary_op, binary_op, is_vector](difference_type i, difference_type j, T init) {
-            return brick_transform_reduce(first+i, first+j, init, binary_op, unary_op, is_vector);
+            __last-__first,
+            [__first, __unary_op](size_t __i) mutable {return __unary_op(__first[__i]); },
+            __init,
+            __binary_op,
+            [__first, __unary_op, __binary_op, __is_vector](_difference_type __i, _difference_type __j, _Tp __init) {
+              return internal::brick_transform_reduce(__first + __i, __first + __j, __init, __binary_op, __unary_op, __is_vector);
         },
-        [first, unary_op, binary_op, result](difference_type i, difference_type j, T init) {
-        return brick_transform_scan(first+i, first+j, result+i, unary_op, init, binary_op, Inclusive()).second;
+        [__first, __unary_op, __binary_op, __result](_difference_type __i, _difference_type __j, _Tp __init) {
+          return internal::brick_transform_scan(__first + __i, __first + __j, __result + __i, __unary_op, __init, __binary_op, _Inclusive()).second;
         });
-        return result+(last-first);
+        return __result + (__last - __first);
     });
 }
 
@@ -190,29 +214,33 @@ OutputIterator pattern_transform_scan(InputIterator first, InputIterator last, O
 // adjacent_difference
 //------------------------------------------------------------------------
 
-template<class InputIterator, class OutputIterator, class BinaryOperation>
-OutputIterator brick_adjacent_difference(InputIterator first, InputIterator last, OutputIterator d_first, BinaryOperation op, /*is_vector*/ std::false_type) noexcept {
-    return std::adjacent_difference(first, last, d_first, op);
+template<class _ForwardIterator, class _OutputIterator, class _BinaryOperation>
+_OutputIterator brick_adjacent_difference(_ForwardIterator __first, _ForwardIterator __last, _OutputIterator __d_first,
+                                          _BinaryOperation __op, /*is_vector*/ std::false_type) noexcept {
+    return std::adjacent_difference(__first, __last, __d_first, __op);
 }
 
-template<class InputIterator, class OutputIterator, class BinaryOperation>
-OutputIterator brick_adjacent_difference(InputIterator first, InputIterator last, OutputIterator d_first, BinaryOperation op, /*is_vector*/ std::true_type) noexcept {
+template<class _ForwardIterator, class _OutputIterator, class _BinaryOperation>
+_OutputIterator brick_adjacent_difference(_ForwardIterator __first, _ForwardIterator __last, _OutputIterator __d_first,
+                                          _BinaryOperation __op, /*is_vector*/ std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Vectorial algorithm unimplemented, referenced to serial");
-    return std::adjacent_difference(first, last, d_first, op);
+    return std::adjacent_difference(__first, __last, __d_first, __op);
 }
 
-template<class InputIterator, class OutputIterator, class BinaryOperation, class IsVector>
-OutputIterator pattern_adjacent_difference(InputIterator first, InputIterator last, OutputIterator d_first, BinaryOperation op, IsVector is_vector, /*is_parallel*/ std::false_type) noexcept {
-    return brick_adjacent_difference(first, last, d_first, op, is_vector);
+template<class _ForwardIterator, class _OutputIterator, class _BinaryOperation, class _IsVector>
+_OutputIterator pattern_adjacent_difference(_ForwardIterator __first, _ForwardIterator __last, _OutputIterator __d_first,
+                                            _BinaryOperation __op, _IsVector __is_vector, /*is_parallel*/ std::false_type) noexcept {
+    return internal::brick_adjacent_difference(__first, __last, __d_first, __op, __is_vector);
 }
 
-template<class InputIterator, class OutputIterator, class BinaryOperation, class IsVector>
-OutputIterator pattern_adjacent_difference(InputIterator first, InputIterator last, OutputIterator d_first, BinaryOperation op, IsVector is_vector, /*is_parallel*/ std::true_type) noexcept {
+template<class _ForwardIterator, class _OutputIterator, class _BinaryOperation, class _IsVector>
+_OutputIterator pattern_adjacent_difference(_ForwardIterator __first, _ForwardIterator __last, _OutputIterator __d_first,
+                                            _BinaryOperation __op, _IsVector __is_vector, /*is_parallel*/ std::true_type) noexcept {
     __PSTL_PRAGMA_MESSAGE("Parallel algorithm unimplemented, referenced to serial");
-    return brick_adjacent_difference(first, last, d_first, op, is_vector);
+    return internal::brick_adjacent_difference(__first, __last, __d_first, __op, __is_vector);
 }
 
 } // namespace internal
-} // namespace pstl
+} // namespace __pstl
 
 #endif /* __PSTL_numeric_impl_H */

--- a/include/pstl/internal/parallel_backend_utils.h
+++ b/include/pstl/internal/parallel_backend_utils.h
@@ -24,104 +24,109 @@
 #include <iterator>
 #include <utility>
 
-namespace pstl {
+namespace __pstl {
 namespace par_backend {
 
 //! Destroy sequence [xs,xe)
 struct serial_destroy {
-    template<typename RandomAccessIterator>
-    void operator()(RandomAccessIterator zs, RandomAccessIterator ze) {
-        typedef typename std::iterator_traits<RandomAccessIterator>::value_type T;
-        while (zs != ze) {
-            --ze;
-            (*ze).~T();
+    template<typename _RandomAccessIterator>
+    void operator()(_RandomAccessIterator __zs, _RandomAccessIterator __ze) {
+        typedef typename std::iterator_traits<_RandomAccessIterator>::value_type _Tp;
+        while (__zs != __ze) {
+            --__ze;
+            (*__ze).~_Tp();
         }
     }
 };
 
 //! Merge sequences [xs,xe) and [ys,ye) to output sequence [zs,(xe-xs)+(ye-ys)), using std::move
 struct serial_move_merge {
-    template<class RandomAccessIterator1, class RandomAccessIterator2, class RandomAccessIterator3, class Compare>
-    void operator()(RandomAccessIterator1 xs, RandomAccessIterator1 xe, RandomAccessIterator2 ys, RandomAccessIterator2 ye, RandomAccessIterator3 zs, Compare comp) {
-        if (xs != xe) {
-            if (ys != ye) {
+    template<class _RandomAccessIterator1, class _RandomAccessIterator2, class _OutputIterator, class _Compare>
+    void operator()(_RandomAccessIterator1 __xs, _RandomAccessIterator1 __xe, _RandomAccessIterator2 __ys, _RandomAccessIterator2 __ye,
+                    _OutputIterator __zs, _Compare __comp) {
+        if (__xs != __xe) {
+            if (__ys != __ye) {
                 for (;;)
-                    if (comp(*ys, *xs)) {
-                        *zs = std::move(*ys);
-                        ++zs;
-                        if (++ys == ye)
+                    if (__comp(*__ys, *__xs)) {
+                        *__zs = std::move(*__ys);
+                        ++__zs;
+                        if (++__ys == __ye)
                             break;
                     }
                     else {
-                        *zs = std::move(*xs);
-                        ++zs;
-                        if (++xs == xe) {
-                            std::move(ys, ye, zs);
+                        *__zs = std::move(*__xs);
+                        ++__zs;
+                        if (++__xs == __xe) {
+                            std::move(__ys, __ye, __zs);
                             return;
                         }
                     }
             }
-            ys = xs;
-            ye = xe;
+            __ys = __xs;
+            __ye = __xe;
         }
-        std::move(ys, ye, zs);
+        std::move(__ys, __ye, __zs);
     }
 };
 
-template<typename RandomAccessIterator1, typename RandomAccessIterator2>
-void init_buf(RandomAccessIterator1 xs, RandomAccessIterator1 xe, RandomAccessIterator2 zs, bool bMove) {
-    const RandomAccessIterator2 ze = zs + (xe - xs);
-    typedef typename std::iterator_traits<RandomAccessIterator2>::value_type T;
-    if (bMove) {
+template<typename _RandomAccessIterator1, typename _OutputIterator>
+void init_buf(_RandomAccessIterator1 __xs, _RandomAccessIterator1 __xe, _OutputIterator __zs, bool __bMove) {
+    const _OutputIterator __ze = __zs + (__xe - __xs);
+    typedef typename std::iterator_traits<_OutputIterator>::value_type _Tp;
+    if (__bMove) {
         // Initialize the temporary buffer and move keys to it.
-        for (; zs != ze; ++xs, ++zs)
-            new(&*zs) T(std::move(*xs));
+        for (; __zs != __ze; ++__xs, ++__zs)
+            new(&*__zs) _Tp(std::move(*__xs));
     }
     else {
         // Initialize the temporary buffer
-        for (; zs != ze; ++zs)
-            new(&*zs) T;
+        for (; __zs != __ze; ++__zs)
+            new(&*__zs) _Tp;
     }
 }
 
-template<typename Buf>
+template<typename _Buf>
 class stack {
-    typedef typename std::iterator_traits<decltype(Buf(0).get())>::value_type T;
-    typedef typename std::iterator_traits<T*>::difference_type difference_type;
+    typedef typename std::iterator_traits<decltype(_Buf(0).get())>::value_type _value_type;
+    typedef typename std::iterator_traits<_value_type*>::difference_type _difference_type;
 
-    Buf my_buf;
-    T* my_ptr;
-    difference_type my_maxsize;
+    _Buf _M_buf;
+    _value_type* _M_ptr;
+    _difference_type _M_maxsize;
 
     stack(const stack&) = delete;
     void operator=(const stack&) = delete;
 public:
-    stack(difference_type max_size): my_buf(max_size), my_maxsize(max_size) { my_ptr = my_buf.get(); }
+    stack(_difference_type __max_size)
+      : _M_buf(__max_size)
+      , _M_maxsize(__max_size)
+    { _M_ptr = _M_buf.get(); }
+
     ~stack() {
-        assert(size() <= my_maxsize);
+        assert(size() <= _M_maxsize);
         while(!empty())
             pop();
     }
 
-    const Buf& buffer() const { return my_buf; }
+    const _Buf& buffer() const { return _M_buf; }
     size_t size() const {
-        assert(my_ptr - my_buf.get() <= my_maxsize);
-        assert(my_ptr - my_buf.get() >= 0);
-        return my_ptr - my_buf.get();
+        assert(_M_ptr - _M_buf.get() <=_M_maxsize);
+        assert(_M_ptr - _M_buf.get() >= 0);
+        return _M_ptr - _M_buf.get();
     }
-    bool empty() const { assert(my_ptr >= my_buf.get()); return my_ptr == my_buf.get();}
-    void push(const T& v) {
-        assert(size() < my_maxsize);
-        new (my_ptr) T(v); ++my_ptr;
+    bool empty() const { assert(_M_ptr >= _M_buf.get()); return _M_ptr == _M_buf.get();}
+    void push(const _value_type& __v) {
+        assert(size() < _M_maxsize);
+        new (_M_ptr) _value_type(__v); ++_M_ptr;
     }
-    const T& top() const { return *(my_ptr-1); }
+    const _value_type& top() const { return *(_M_ptr-1); }
     void pop() {
-        assert(my_ptr > my_buf.get());
-        --my_ptr; (*my_ptr).~T();
+        assert(_M_ptr > _M_buf.get());
+        --_M_ptr; (*_M_ptr).~_value_type();
     }
 };
 
 } // namespace par_backend
-} // namespace pstl
+} // namespace __pstl
 
 #endif /* __PSTL_parallel_backend_utils_H */

--- a/include/pstl/internal/parallel_backend_utils.h
+++ b/include/pstl/internal/parallel_backend_utils.h
@@ -31,10 +31,10 @@ namespace par_backend {
 struct serial_destroy {
     template<typename _RandomAccessIterator>
     void operator()(_RandomAccessIterator __zs, _RandomAccessIterator __ze) {
-        typedef typename std::iterator_traits<_RandomAccessIterator>::value_type _Tp;
+        typedef typename std::iterator_traits<_RandomAccessIterator>::value_type _ValueType;
         while (__zs != __ze) {
             --__ze;
-            (*__ze).~_Tp();
+            (*__ze).~_ValueType();
         }
     }
 };
@@ -72,32 +72,32 @@ struct serial_move_merge {
 template<typename _RandomAccessIterator1, typename _OutputIterator>
 void init_buf(_RandomAccessIterator1 __xs, _RandomAccessIterator1 __xe, _OutputIterator __zs, bool __bMove) {
     const _OutputIterator __ze = __zs + (__xe - __xs);
-    typedef typename std::iterator_traits<_OutputIterator>::value_type _Tp;
+    typedef typename std::iterator_traits<_OutputIterator>::value_type _ValueType;
     if (__bMove) {
         // Initialize the temporary buffer and move keys to it.
         for (; __zs != __ze; ++__xs, ++__zs)
-            new(&*__zs) _Tp(std::move(*__xs));
+            new(&*__zs) _ValueType(std::move(*__xs));
     }
     else {
         // Initialize the temporary buffer
         for (; __zs != __ze; ++__zs)
-            new(&*__zs) _Tp;
+            new(&*__zs) _ValueType;
     }
 }
 
 template<typename _Buf>
 class stack {
-    typedef typename std::iterator_traits<decltype(_Buf(0).get())>::value_type _value_type;
-    typedef typename std::iterator_traits<_value_type*>::difference_type _difference_type;
+    typedef typename std::iterator_traits<decltype(_Buf(0).get())>::value_type _ValueType;
+    typedef typename std::iterator_traits<_ValueType*>::difference_type _DifferenceType;
 
     _Buf _M_buf;
-    _value_type* _M_ptr;
-    _difference_type _M_maxsize;
+    _ValueType* _M_ptr;
+    _DifferenceType _M_maxsize;
 
     stack(const stack&) = delete;
     void operator=(const stack&) = delete;
 public:
-    stack(_difference_type __max_size)
+    stack(_DifferenceType __max_size)
       : _M_buf(__max_size)
       , _M_maxsize(__max_size)
     { _M_ptr = _M_buf.get(); }
@@ -115,14 +115,14 @@ public:
         return _M_ptr - _M_buf.get();
     }
     bool empty() const { assert(_M_ptr >= _M_buf.get()); return _M_ptr == _M_buf.get();}
-    void push(const _value_type& __v) {
+    void push(const _ValueType& __v) {
         assert(size() < _M_maxsize);
-        new (_M_ptr) _value_type(__v); ++_M_ptr;
+        new (_M_ptr) _ValueType(__v); ++_M_ptr;
     }
-    const _value_type& top() const { return *(_M_ptr-1); }
+    const _ValueType& top() const { return *(_M_ptr-1); }
     void pop() {
         assert(_M_ptr > _M_buf.get());
-        --_M_ptr; (*_M_ptr).~_value_type();
+        --_M_ptr; (*_M_ptr).~_ValueType();
     }
 };
 

--- a/include/pstl/internal/parallel_impl.h
+++ b/include/pstl/internal/parallel_impl.h
@@ -37,10 +37,10 @@ namespace internal {
 Each f[i,j) must return a value in [i,j). */
 template<class _Index, class _Brick, class _Compare>
 _Index parallel_find(_Index __first, _Index __last, _Brick __f, _Compare __comp, bool __b_first) {
-    typedef typename std::iterator_traits<_Index>::difference_type _difference_type;
-    const _difference_type __n = __last - __first;
-    _difference_type __initial_dist = __b_first ? __n : -1;
-    std::atomic<_difference_type> __extremum(__initial_dist);
+    typedef typename std::iterator_traits<_Index>::difference_type _DifferenceType;
+    const _DifferenceType __n = __last - __first;
+    _DifferenceType __initial_dist = __b_first ? __n : -1;
+    std::atomic<_DifferenceType> __extremum(__initial_dist);
     // TODO: find out what is better here: parallel_for or parallel_reduce
     par_backend::parallel_for(__first, __last, [__comp, __f, __first, &__extremum](_Index __i, _Index __j) {
         // See "Reducing Contention Through Priority Updates", PPoPP '13, for discussion of
@@ -49,8 +49,8 @@ _Index parallel_find(_Index __first, _Index __last, _Brick __f, _Compare __comp,
             _Index __res = __f(__i, __j);
             // If not '__last' returned then we found what we want so put this to extremum
             if (__res != __j) {
-                const _difference_type __k = __res - __first;
-                for (_difference_type __old = __extremum; __comp(__k, __old); __old = __extremum) {
+                const _DifferenceType __k = __res - __first;
+                for (_DifferenceType __old = __extremum; __comp(__k, __old); __old = __extremum) {
                     __extremum.compare_exchange_weak(__old, __k);
                 }
             }

--- a/include/pstl/internal/unseq_backend_simd.h
+++ b/include/pstl/internal/unseq_backend_simd.h
@@ -190,19 +190,19 @@ __PSTL_PRAGMA_SIMD_REDUCTION(|:__found)
 }
 
 template<class _Index, class _DifferenceType, class _Pred>
-_DifferenceType simd_count(_Index __index, _DifferenceType __n, _Pred pred) noexcept {
+_DifferenceType simd_count(_Index __index, _DifferenceType __n, _Pred __pred) noexcept {
     _DifferenceType __count = 0;
 __PSTL_PRAGMA_SIMD_REDUCTION(+:__count)
     for (_DifferenceType __i = 0; __i < __n; ++__i)
-        if (pred(*(__index + __i)))
+        if (__pred(*(__index + __i)))
             ++__count;
 
     return __count;
 }
 
-template<class _InputIterator, class _DifferenceType, class _OutputIterator, class __BinaryPredicate>
+template<class _InputIterator, class _DifferenceType, class _OutputIterator, class _BinaryPredicate>
 _OutputIterator simd_unique_copy(_InputIterator __first, _DifferenceType __n, _OutputIterator __result,
-                                 __BinaryPredicate __pred) noexcept {
+                                 _BinaryPredicate __pred) noexcept {
     if (__n == 0)
         return __result;
 
@@ -229,8 +229,8 @@ __PSTL_PRAGMA_SIMD
     return __result + __n;
 }
 
-template<class _InputIterator, class _DifferenceType, class _OutputIterator, class UnaryPredicate>
-_OutputIterator simd_copy_if(_InputIterator __first, _DifferenceType __n, _OutputIterator __result, UnaryPredicate __pred) noexcept {
+template<class _InputIterator, class _DifferenceType, class _OutputIterator, class _UnaryPredicate>
+_OutputIterator simd_copy_if(_InputIterator __first, _DifferenceType __n, _OutputIterator __result, _UnaryPredicate __pred) noexcept {
     _DifferenceType __cnt = 0;
 
 __PSTL_PRAGMA_SIMD
@@ -244,8 +244,8 @@ __PSTL_PRAGMA_SIMD
     return __result + __cnt;
 }
 
-template<class _InputIterator, class _DifferenceType, class BinaryPredicate>
-_DifferenceType simd_calc_mask_2(_InputIterator __first, _DifferenceType __n, bool* __restrict __mask, BinaryPredicate __pred) noexcept {
+template<class _InputIterator, class _DifferenceType, class _BinaryPredicate>
+_DifferenceType simd_calc_mask_2(_InputIterator __first, _DifferenceType __n, bool* __restrict __mask, _BinaryPredicate __pred) noexcept {
     _DifferenceType __count = 0;
 
 __PSTL_PRAGMA_SIMD_REDUCTION(+:__count)
@@ -256,8 +256,8 @@ __PSTL_PRAGMA_SIMD_REDUCTION(+:__count)
     return __count;
 }
 
-template<class _InputIterator, class _DifferenceType, class UnaryPredicate>
-_DifferenceType simd_calc_mask_1(_InputIterator __first, _DifferenceType __n, bool* __restrict __mask, UnaryPredicate __pred) noexcept {
+template<class _InputIterator, class _DifferenceType, class _UnaryPredicate>
+_DifferenceType simd_calc_mask_1(_InputIterator __first, _DifferenceType __n, bool* __restrict __mask, _UnaryPredicate __pred) noexcept {
     _DifferenceType __count = 0;
 
 __PSTL_PRAGMA_SIMD_REDUCTION(+:__count)
@@ -442,7 +442,7 @@ _ForwardIterator1 simd_find_first_of(_ForwardIterator1 __first, _ForwardIterator
     }
 
     // Common case
-    // If __first sequence larger than second then we'll run simd___first with parameters of __first sequence.
+    // If first sequence larger than second then we'll run simd_first with parameters of first sequence.
     // Otherwise, vice versa.
     if (__n1 < __n2)
     {

--- a/include/pstl/internal/unseq_backend_simd.h
+++ b/include/pstl/internal/unseq_backend_simd.h
@@ -248,7 +248,7 @@ template<class _InputIterator, class _DifferenceType, class BinaryPredicate>
 _DifferenceType simd_calc_mask_2(_InputIterator __first, _DifferenceType __n, bool* __restrict __mask, BinaryPredicate __pred) noexcept {
     _DifferenceType __count = 0;
 
-__PSTL_PRAGMA_SIMD_REDUCTION(+:count)
+__PSTL_PRAGMA_SIMD_REDUCTION(+:__count)
     for (_DifferenceType __i = 0; __i < __n; ++__i) {
         __mask[__i] = !__pred(__first[__i], __first[__i - 1]);
         __count += __mask[__i];
@@ -328,7 +328,7 @@ _Index simd_adjacent_find(_Index __first, _Index __last, _BinaryPredicate __pred
 #if __PSTL_EARLYEXIT_PRESENT
     //Some compiler versions fail to compile the following loop when iterators are used. Indices are used instead
     const _difference_type __n = __last - __first-1;
-__PSTL_PRAGMA_VECT__OR_UNALIGNED
+__PSTL_PRAGMA_VECTOR_UNALIGNED
 __PSTL_PRAGMA_SIMD_EARLYEXIT
     for(; __i < __n; ++__i)
         if(pred(__first[__i], __first[__i + 1]))
@@ -343,7 +343,7 @@ __PSTL_PRAGMA_SIMD_EARLYEXIT
     while ( __last - __first >= __block_size ) {
         _difference_type __found = 0;
 __PSTL_PRAGMA_VECTOR_UNALIGNED // Do not generate peel loop part
-__PSTL_PRAGMA_SIMD_REDUCTION(|:_found)
+__PSTL_PRAGMA_SIMD_REDUCTION(|:__found)
         for ( __i = 0; __i < __block_size-1; ++__i ) {
             //TODO: to improve SIMD vectorization
             const _difference_type __t = __pred(*(__first + __i), *(__first + __i + 1));

--- a/include/pstl/internal/unseq_backend_simd.h
+++ b/include/pstl/internal/unseq_backend_simd.h
@@ -322,12 +322,12 @@ _Index simd_adjacent_find(_Index __first, _Index __last, _BinaryPredicate __pred
     if(__last - __first < 2)
         return __last;
 
-    typedef typename std::iterator_traits<_Index>::difference_type _difference_type;
-    _difference_type __i = 0;
+    typedef typename std::iterator_traits<_Index>::difference_type _DifferenceType;
+    _DifferenceType __i = 0;
 
 #if __PSTL_EARLYEXIT_PRESENT
     //Some compiler versions fail to compile the following loop when iterators are used. Indices are used instead
-    const _difference_type __n = __last - __first-1;
+    const _DifferenceType __n = __last - __first-1;
 __PSTL_PRAGMA_VECTOR_UNALIGNED
 __PSTL_PRAGMA_SIMD_EARLYEXIT
     for(; __i < __n; ++__i)
@@ -338,15 +338,15 @@ __PSTL_PRAGMA_SIMD_EARLYEXIT
 #else
     // Experiments show good block sizes like this
     //TODO: to consider tuning block_size for various data types
-    const _difference_type __block_size = 8;
-    alignas(64) _difference_type __lane[__block_size] = {0};
+    const _DifferenceType __block_size = 8;
+    alignas(64) _DifferenceType __lane[__block_size] = {0};
     while ( __last - __first >= __block_size ) {
-        _difference_type __found = 0;
+        _DifferenceType __found = 0;
 __PSTL_PRAGMA_VECTOR_UNALIGNED // Do not generate peel loop part
 __PSTL_PRAGMA_SIMD_REDUCTION(|:__found)
         for ( __i = 0; __i < __block_size-1; ++__i ) {
             //TODO: to improve SIMD vectorization
-            const _difference_type __t = __pred(*(__first + __i), *(__first + __i + 1));
+            const _DifferenceType __t = __pred(*(__first + __i), *(__first + __i + 1));
             __lane[__i] = __t;
             __found |= __t;
         }
@@ -433,10 +433,10 @@ __PSTL_PRAGMA_SIMD_ORDERED_MONOTONIC_2ARGS(__cnt_true:1, __cnt_false : 1)
 template<class _ForwardIterator1, class _ForwardIterator2, class _BinaryPredicate>
 _ForwardIterator1 simd_find_first_of(_ForwardIterator1 __first, _ForwardIterator1 __last, _ForwardIterator2 __s_first,
                                      _ForwardIterator2 __s_last, _BinaryPredicate __pred) noexcept {
-    typedef typename std::iterator_traits<_ForwardIterator1>::difference_type _difference_type;
+    typedef typename std::iterator_traits<_ForwardIterator1>::difference_type _DifferencType;
 
-    const _difference_type __n1 = __last - __first;
-    const _difference_type __n2 = __s_last - __s_first;
+    const _DifferencType __n1 = __last - __first;
+    const _DifferencType __n2 = __s_last - __s_first;
     if (__n1 == 0 || __n2 == 0) {
         return __last; // according to the standard
     }
@@ -455,8 +455,8 @@ _ForwardIterator1 simd_find_first_of(_ForwardIterator1 __first, _ForwardIterator
     }
     else {
         for (; __s_first != __s_last; ++__s_first) {
-            const auto __result = unseq_backend::simd_first(__first, _difference_type(0), __n1,
-                [__s_first, &__pred](_ForwardIterator1 __it, _difference_type __i) {return __pred(__it[__i], *__s_first); });
+            const auto __result = unseq_backend::simd_first(__first, _DifferencType(0), __n1,
+                [__s_first, &__pred](_ForwardIterator1 __it, _DifferencType __i) {return __pred(__it[__i], *__s_first); });
             if (__result != __last) {
                 return __result;
             }

--- a/include/pstl/iterators.h
+++ b/include/pstl/iterators.h
@@ -28,15 +28,15 @@
 #if __PSTL_CPP14_INTEGER_SEQUENCE_PRESENT
 
 #include <utility>
-namespace pstl {
+namespace __pstl {
     namespace internal {
         using std::index_sequence;
         using std::make_index_sequence;
     } //internal
-}//namespace pstl
+}//namespace __pstl
 
 #else //std::integer_sequence is not present
-namespace pstl {
+namespace __pstl {
     namespace internal {
 template<std::size_t... S> class index_sequence {};
 template<std::size_t N, std::size_t... S>
@@ -47,10 +47,10 @@ struct make_index_sequence_impl <0, S...> {
 };
 template<std::size_t N> struct make_index_sequence: internal::make_index_sequence_impl<N>::type {};
 } //internal
-}//namespace pstl
+}//namespace __pstl
 #endif
 
-namespace pstl {
+namespace __pstl {
 namespace internal {
 
 template<size_t N>
@@ -79,7 +79,7 @@ struct tuple_util<0> {
 template <typename TupleReturnType>
 struct make_references {
     template <typename TupleType, std::size_t... Is>
-    TupleReturnType operator()(const TupleType& t, pstl::internal::index_sequence<Is...>) {
+    TupleReturnType operator()(const TupleType& t, __pstl::internal::index_sequence<Is...>) {
         return std::tie((*std::get<Is>(t))...);
     }
 };
@@ -147,7 +147,7 @@ public:
     explicit zip_iterator(Types... args): my_it(std::make_tuple(args...)) {}
 
     reference operator*() {
-        return internal::make_references<reference>()(my_it, pstl::internal::make_index_sequence<num_types>());
+        return internal::make_references<reference>()(my_it, __pstl::internal::make_index_sequence<num_types>());
     }
     reference operator[](difference_type i) const { return *(*this + i); }
 
@@ -202,6 +202,6 @@ private:
 template<typename... T>
 zip_iterator<T...> make_zip_iterator(T... args) { return zip_iterator<T...>(args...); }
 
-} //namespace pstl
+} //namespace __pstl
 
 #endif /* __PSTL_iterators_H */

--- a/test/test_iterators.cpp
+++ b/test/test_iterators.cpp
@@ -64,8 +64,8 @@ struct test_counting_iterator {
     template <typename Policy, typename T, typename IntType>
     void operator()( Policy exec, Sequence<T>& in, IntType begin, IntType end, const T& value) {
 
-        auto b = pstl::counting_iterator<IntType>(begin);
-        auto e = pstl::counting_iterator<IntType>(end);
+        auto b = __pstl::counting_iterator<IntType>(begin);
+        auto e = __pstl::counting_iterator<IntType>(end);
 
         //checks in using
         std::for_each(exec, b, e, [&in, &value](IntType i) { in[i] = value; });
@@ -77,7 +77,7 @@ struct test_counting_iterator {
         EXPECT_TRUE(*(b + 1) == 1, "wrong result with operator+ for an iterator");
         EXPECT_TRUE(*(b+=1) == 1, "wrong result with operator+= for an iterator");
 
-        b = pstl::counting_iterator<IntType>(begin);
+        b = __pstl::counting_iterator<IntType>(begin);
         test_random_iterator(b);
     }
 };
@@ -85,8 +85,8 @@ struct test_counting_iterator {
 struct test_zip_iterator {
     template <typename Policy, typename T1, typename T2>
     void operator()( Policy exec, Sequence<T1>& in1, Sequence<T2>& in2) {
-        auto b = pstl::make_zip_iterator(in1.begin(), in2.begin());
-        auto e = pstl::make_zip_iterator(in1.end(), in2.end());
+        auto b = __pstl::make_zip_iterator(in1.begin(), in2.begin());
+        auto e = __pstl::make_zip_iterator(in1.end(), in2.end());
 
         //checks in using
         std::for_each(exec, b, e, [](const std::tuple<T1&, T2&>& a) { std::get<0>(a) = 1, std::get<1>(a) = 1;});
@@ -104,24 +104,24 @@ void test_iterator_by_type(IntType n) {
     const IntType end = n;
     Sequence<T> in(end-beg, [](size_t)->T { return T(0); }); //fill with zeros
     T value = -1;
-    test_counting_iterator()(pstl::execution::seq, in, beg, end, value);
-    test_counting_iterator()(pstl::execution::unseq, in, beg, end, value);
-    test_counting_iterator()(pstl::execution::par, in, beg, end, value);
-    test_counting_iterator()(pstl::execution::par_unseq, in, beg, end, value);
+    test_counting_iterator()(__pstl::execution::seq, in, beg, end, value);
+    test_counting_iterator()(__pstl::execution::unseq, in, beg, end, value);
+    test_counting_iterator()(__pstl::execution::par, in, beg, end, value);
+    test_counting_iterator()(__pstl::execution::par_unseq, in, beg, end, value);
 
     Sequence<IntType> in2(end-beg, [](size_t)->IntType { return IntType(0); }); //fill with zeros
 
     // Zip Iterator doesn't work correctly with unseq and par_unseq policies with compilers older than icc 18
     #if (__INTEL_COMPILER && __INTEL_COMPILER<1800)
-        test_zip_iterator()(pstl::execution::seq, in, in2);
+        test_zip_iterator()(__pstl::execution::seq, in, in2);
         #if __PSTL_USE_PAR_POLICIES
-            test_zip_iterator()(pstl::execution::par, in, in2);
+            test_zip_iterator()(__pstl::execution::par, in, in2);
         #endif
     #else
-    test_zip_iterator()(pstl::execution::seq, in, in2);
-    test_zip_iterator()(pstl::execution::unseq, in, in2);
-    test_zip_iterator()(pstl::execution::par, in, in2);
-    test_zip_iterator()(pstl::execution::par_unseq, in, in2);
+    test_zip_iterator()(__pstl::execution::seq, in, in2);
+    test_zip_iterator()(__pstl::execution::unseq, in, in2);
+    test_zip_iterator()(__pstl::execution::par, in, in2);
+    test_zip_iterator()(__pstl::execution::par_unseq, in, in2);
     #endif
 }
 

--- a/test/test_mismatch.cpp
+++ b/test/test_mismatch.cpp
@@ -47,7 +47,7 @@ struct test_mismatch {
         using namespace std;
         typedef typename iterator_traits<Iterator1>::value_type T;
         {
-            const auto expected = mismatch(pstl::execution::seq, first1, last1, first2, last2, std::equal_to<T>());
+            const auto expected = mismatch(__pstl::execution::seq, first1, last1, first2, last2, std::equal_to<T>());
             const auto res1 = mismatch(exec, first1, last1, first2, last2, std::equal_to<T>());
             EXPECT_TRUE(expected == res1, "wrong return result from mismatch");
             const auto res2 = mismatch(exec, first1, last1, first2, last2);

--- a/test/test_partition_copy.cpp
+++ b/test/test_partition_copy.cpp
@@ -40,17 +40,17 @@ struct test_partition_copy {
         EXPECT_TRUE(std::distance(true_first, actual_ret.first) ==
             std::count_if(first, last, unary_op), "partition_copy has wrong effect from true sequence");
         EXPECT_TRUE(std::distance(false_first, actual_ret.second) ==
-            std::count_if(first, last, pstl::internal::not_pred<UnaryOp>(unary_op)), "partition_copy has wrong effect from false sequence");
+            std::count_if(first, last, __pstl::internal::not_pred<UnaryOp>(unary_op)), "partition_copy has wrong effect from false sequence");
     }
 
     //dummy specialization by iterator type and policy type, in case of broken configuration
 #if __PSTL_ICC_1800_TEST_MONOTONIC_RELEASE_64_BROKEN
     template <typename InputIterator, typename OutputIterator, typename OutputIterator2, typename UnaryOp>
-    void operator()(pstl::execution::unsequenced_policy, std::reverse_iterator<InputIterator> first, std::reverse_iterator<InputIterator> last,
+    void operator()(__pstl::execution::unsequenced_policy, std::reverse_iterator<InputIterator> first, std::reverse_iterator<InputIterator> last,
         std::reverse_iterator<OutputIterator> true_first, std::reverse_iterator<OutputIterator> true_last,
         std::reverse_iterator<OutputIterator2> false_first, OutputIterator2 false_last, UnaryOp unary_op) { }
     template <typename InputIterator, typename OutputIterator, typename OutputIterator2, typename UnaryOp>
-    void operator()(pstl::execution::parallel_unsequenced_policy, std::reverse_iterator<InputIterator> first, std::reverse_iterator<InputIterator> last,
+    void operator()(__pstl::execution::parallel_unsequenced_policy, std::reverse_iterator<InputIterator> first, std::reverse_iterator<InputIterator> last,
         std::reverse_iterator<OutputIterator> true_first, std::reverse_iterator<OutputIterator> true_last,
         std::reverse_iterator<OutputIterator2> false_first, OutputIterator2 false_last, UnaryOp unary_op) { }
 #endif

--- a/test/test_reduce.cpp
+++ b/test/test_reduce.cpp
@@ -49,7 +49,7 @@ void test_long_form(T init, BinaryOp binary_op, F f) {
         using namespace std;
 
         // Try policy-free version
-        T result = pstl::internal::brick_transform_reduce( in.cfbegin(), in.cfend(), init, binary_op, pstl::internal::no_op(), std::false_type() );
+        T result = __pstl::internal::brick_transform_reduce( in.cfbegin(), in.cfend(), init, binary_op, __pstl::internal::no_op(), std::false_type() );
         EXPECT_EQ( expected, result, "bad result from reduce(first, last, init, binary_op_op)" );
 
         invoke_on_all_policies(test_long_forms_for_one_policy(), in.begin(), in.end(), init, binary_op, expected);
@@ -61,9 +61,9 @@ struct test_two_short_forms {
 
 #if __PSTL_ICC_16_VC14_TEST_PAR_TBB_RT_RELEASE_64_BROKEN //dummy specialization by policy type, in case of broken configuration
     template <typename Iterator>
-    void operator()(pstl::execution::parallel_policy, Iterator first, Iterator last, Sum init, Sum expected) { }
+    void operator()(__pstl::execution::parallel_policy, Iterator first, Iterator last, Sum init, Sum expected) { }
     template <typename Iterator>
-    void operator()(pstl::execution::parallel_unsequenced_policy, Iterator first, Iterator last, Sum init, Sum expected) { }
+    void operator()(__pstl::execution::parallel_unsequenced_policy, Iterator first, Iterator last, Sum init, Sum expected) { }
 #endif
 
     template <typename Policy, typename Iterator>

--- a/test/test_replace.cpp
+++ b/test/test_replace.cpp
@@ -122,7 +122,7 @@ void test(Pred pred) {
 }
 
 int32_t main() {
-    test<int32_t, float32_t>  (pstl::internal::equal_value<int32_t>(666));
+    test<int32_t, float32_t>  (__pstl::internal::equal_value<int32_t>(666));
     test<uint16_t, uint8_t> ([](const uint16_t& elem) { return elem % 3 < 2; });
     test<float64_t, int64_t>([](const float64_t& elem) { return elem * elem - 3.5 * elem > 10; });
     test<copy_int, copy_int> ([](const copy_int& val) { return val.value / 5 > 2; });

--- a/test/test_transform_reduce.cpp
+++ b/test/test_transform_reduce.cpp
@@ -79,7 +79,7 @@ struct test_transform_reduce {
         T init, BinaryOperation1 opB1, BinaryOperation2 opB2, UnaryOp opU) {
 
         auto expectedB = std::inner_product(first1, last1, first2, init, opB1, opB2);
-        auto expectedU = pstl::internal::brick_transform_reduce(first1, last1, init, opB1, opU, std::false_type());
+        auto expectedU = __pstl::internal::brick_transform_reduce(first1, last1, init, opB1, opU, std::false_type());
         T resRA = std::transform_reduce(exec, first1, last1, first2, init, opB1, opB2);
         CheckResults(expectedB, resRA);
         resRA = std::transform_reduce(exec, first1, last1, init, opB1, opU);

--- a/test/test_transform_scan.cpp
+++ b/test/test_transform_scan.cpp
@@ -44,8 +44,8 @@ struct test_transform_scan {
         using namespace std;
 
         auto orr1 = inclusive ?
-            transform_inclusive_scan(pstl::execution::seq, first, last, expected_first, binary_op, unary_op, init) :
-            transform_exclusive_scan(pstl::execution::seq, first, last, expected_first, init, binary_op, unary_op);
+            transform_inclusive_scan(__pstl::execution::seq, first, last, expected_first, binary_op, unary_op, init) :
+            transform_exclusive_scan(__pstl::execution::seq, first, last, expected_first, init, binary_op, unary_op);
         auto orr2 = inclusive ?
             transform_inclusive_scan(exec, first, last, out_first, binary_op, unary_op, init) :
             transform_exclusive_scan(exec, first, last, out_first, init, binary_op, unary_op);
@@ -54,7 +54,7 @@ struct test_transform_scan {
 
         // Checks inclusive scan if init is not provided
         if(inclusive && n > 0) {
-            orr1 = transform_inclusive_scan(pstl::execution::seq, first, last, expected_first, binary_op, unary_op);
+            orr1 = transform_inclusive_scan(__pstl::execution::seq, first, last, expected_first, binary_op, unary_op);
             orr2 = transform_inclusive_scan(exec, first, last, out_first, binary_op, unary_op);
             EXPECT_TRUE(out_last == orr2, "transform...scan returned wrong iterator");
             check_and_reset(expected_first, out_first, n, trash);
@@ -92,8 +92,8 @@ void test( UnaryOp unary_op, Out init, BinaryOp binary_op, Out trash ) {
         Sequence<Out> out(n, [&](size_t) {return trash;});
 
         auto result = inclusive ?
-                      pstl::internal::brick_transform_scan(in.cbegin(), in.cend(), out.fbegin(), unary_op, init, binary_op, std::true_type()/*inclusive*/) :
-                      pstl::internal::brick_transform_scan(in.cbegin(), in.cend(), out.fbegin(), unary_op, init, binary_op, std::false_type()/*exclusive*/);
+                      __pstl::internal::brick_transform_scan(in.cbegin(), in.cend(), out.fbegin(), unary_op, init, binary_op, std::true_type()/*inclusive*/) :
+                      __pstl::internal::brick_transform_scan(in.cbegin(), in.cend(), out.fbegin(), unary_op, init, binary_op, std::false_type()/*exclusive*/);
         check_and_reset( expected.begin(), out.begin(), out.size(), trash );
 
         invoke_on_all_policies(test_transform_scan(), in.begin(), in.end(), out.begin(), out.end(), expected.begin(), expected.end(), in.size(), unary_op, init, binary_op, trash);

--- a/test/utils.h
+++ b/test/utils.h
@@ -637,7 +637,7 @@ struct invoke_on_all_iterator_types {
 // Invoke op(policy,rest...) for each possible policy.
 template<typename Op, typename... T>
 void invoke_on_all_policies(Op op, T&&... rest) {
-    using namespace pstl::execution;
+    using namespace __pstl::execution;
 
     // Try static execution policies
     invoke_on_all_iterator_types()(seq, op, std::forward<T>(rest)...);


### PR DESCRIPTION
The gist of this change is to rename all public template parameters, arguments, and locals in line with libstdc++ "uglification" protocols to avoid issues with preprocessor macros colliding with our internal identifier names.

Also, the using namespace declarations have been adjusted to avoid ADL name collision issues.

** Please note this is the first set of changes of this nature
This *must* be applied to *every* implementation file. I have held off applying these changes to the rest of include/pstl/internal because I want to avoid any major merge conflicts with backend updates.

I would like to amend this pull request with the rest of the changes, but I need to request that you hold off on *any* concurrent changes to files under include/pstl until this pull req is complete and accepted. 

Also Note, I'm not sure why git insisted on registering "empty" merges for the pull req you have already accepted, but this is baselined against that merge from upstream.